### PR TITLE
feat: Add a Nexus HTTP client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,7 +71,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -82,7 +82,16 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "approx"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f2a05fd1bd10b2527e20a2cd32d8873d115b8b39fe219ee25f42a8aca6ba278"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -92,6 +101,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 dependencies = [
  "derive_arbitrary",
+]
+
+[[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "async-compression"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "async-tungstenite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8acc405d38be14342132609f06f02acaf825ddccfe76c4824a69281e0458ebd4"
+dependencies = [
+ "atomic-waker",
+ "futures-core",
+ "futures-io",
+ "futures-task",
+ "futures-util",
+ "log",
+ "pin-project-lite",
+ "tungstenite 0.28.0",
 ]
 
 [[package]]
@@ -105,6 +158,29 @@ name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
 
 [[package]]
 name = "axum"
@@ -254,10 +330,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a88b7ea17d208c4193f2c1e6de3c35fe71f98c96982d5ced308bdcc749ff6e1f"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -266,12 +367,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
+name = "capnp"
+version = "0.25.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4777a3bc19b8f8e5fb2d0196c6b5dfcbbcc8b2fe08ae57f873f2f35f15cfc210"
+dependencies = [
+ "embedded-io",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -280,6 +392,34 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
+name = "cgmath"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a98d30140e3296250832bbaaff83b27dcd6fa3cc70fb6f1f3e5c9c0023b5317"
+dependencies = [
+ "approx",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
@@ -326,7 +466,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -336,10 +476,119 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "colored"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
+
+[[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "log",
+ "publicsuffix",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "core-foundation-sys"
@@ -352,6 +601,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -387,8 +645,18 @@ version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -402,7 +670,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -411,9 +692,20 @@ version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core",
+ "darling_core 0.21.3",
  "quote",
- "syn",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -464,7 +756,7 @@ checksum = "780eb241654bf097afb00fc5f054a09b687dad862e485fdcf8399bb056565370"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -472,6 +764,20 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "derive-where"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d08b3a0bcc0d079199cd476b2cae8435016ec11d1c0986c6901c5ac223041534"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "derive_arbitrary"
@@ -481,7 +787,43 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "derive_more"
+version = "0.99.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
+dependencies = [
+ "convert_case 0.4.0",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case 0.10.0",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.118",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -524,7 +866,7 @@ dependencies = [
  "dsl_auto_type",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -544,7 +886,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe2444076b48641147115697648dc743c2c00b61adade0f01ce67133c7babe8c"
 dependencies = [
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -565,7 +907,16 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -580,19 +931,58 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd122633e4bef06db27737f21d3738fb89c8f6d5360d6d9d7635dda142a7757e"
 dependencies = [
- "darling",
+ "darling 0.21.3",
  "either",
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
+name = "embedded-io"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eb1aa714776b75c7e67e1da744b81a129b3ff919c8712b5e1b32252c1f07cc7"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "enum_dispatch"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
+dependencies = [
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "env_filter"
@@ -622,13 +1012,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "erased-serde"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
+dependencies = [
+ "serde",
+ "serde_core",
+ "typeid",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -642,6 +1043,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -662,6 +1069,12 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
@@ -674,6 +1087,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "funty"
@@ -737,7 +1156,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -776,6 +1195,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -783,6 +1211,19 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -804,8 +1245,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -832,12 +1276,18 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -847,11 +1297,20 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
- "foldhash",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -871,6 +1330,18 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "html-escape"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c1ff2d1cbf39efe5af0900ced8a069b5e61557a17544eb0c4a50239937389e"
 
 [[package]]
 name = "http"
@@ -924,6 +1395,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "hugr"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfeda31e63730f62e6df41951734ef469a15eead870650c36d1cf9a8a3bcc081"
+dependencies = [
+ "hugr-core",
+ "hugr-model",
+]
+
+[[package]]
+name = "hugr-core"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad6b20b51ff584be10c85f29890314f8074893879788dd48a9721eaa124f2437"
+dependencies = [
+ "base64",
+ "cgmath",
+ "delegate",
+ "derive_more 2.1.1",
+ "downcast-rs",
+ "enum_dispatch",
+ "html-escape",
+ "hugr-model",
+ "indexmap 2.14.0",
+ "itertools 0.14.0",
+ "ordered-float",
+ "pastey",
+ "petgraph",
+ "portgraph",
+ "regex",
+ "relrc",
+ "rustc-hash",
+ "schemars 1.2.1",
+ "semver",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "smallvec",
+ "smol_str",
+ "static_assertions",
+ "strum",
+ "thiserror 2.0.18",
+ "tracing",
+ "typetag",
+ "zstd",
+]
+
+[[package]]
+name = "hugr-model"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fde0757c0a4704ecd277d937289b73b862075f9caffbdaf43ddf3d21bc01b9aa"
+dependencies = [
+ "base64",
+ "bumpalo",
+ "capnp",
+ "derive_more 2.1.1",
+ "indexmap 2.14.0",
+ "itertools 0.14.0",
+ "ordered-float",
+ "pest",
+ "pest_derive",
+ "pretty",
+ "rustc-hash",
+ "semver",
+ "smol_str",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "hyper"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -942,6 +1483,22 @@ dependencies = [
  "pin-project-lite",
  "smallvec",
  "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
 ]
 
 [[package]]
@@ -950,13 +1507,23 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64",
  "bytes",
+ "futures-channel",
+ "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
  "pin-project-lite",
+ "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
+ "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -1094,6 +1661,17 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
@@ -1103,6 +1681,21 @@ dependencies = [
  "serde",
  "serde_core",
 ]
+
+[[package]]
+name = "inventory"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "is_ci"
@@ -1118,6 +1711,15 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -1130,6 +1732,65 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.3",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -1184,6 +1845,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1197,6 +1864,12 @@ name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matchers"
@@ -1247,7 +1920,7 @@ checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1305,7 +1978,32 @@ checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "mockito"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90820618712cab19cfc46b274c6c22546a82affcb3c3bdf0f29e3db8e1bb92c0"
+dependencies = [
+ "assert-json-diff",
+ "bytes",
+ "colored",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "pin-project-lite",
+ "rand 0.9.4",
+ "regex",
+ "serde_json",
+ "serde_urlencoded",
+ "similar",
+ "tokio",
 ]
 
 [[package]]
@@ -1314,7 +2012,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1396,10 +2094,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+dependencies = [
+ "num-traits",
+ "rand 0.8.7",
+ "serde",
+]
+
+[[package]]
 name = "owo-colors"
 version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
 
 [[package]]
 name = "parking_lot_core"
@@ -1421,10 +2146,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pest"
+version = "2.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47627dd7305c6a2d6c8c6bcd24c5a4c17dbbf425f4f9c5313e724b38fc9782e9"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b4254325ecad416ab689e27ba51da03ba01a9632bc6e108f5fe7c3c4ad29d58"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c4c0e91ead7a8f7acecbca6f003fc2e8282b1dbe2dd9c9d2f16aba42995e0a7"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9744bc48116fee06334924bb5f2bad41eed5e89bd26e29b0b799f9a3f82c210"
+dependencies = [
+ "pest",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+ "serde",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1445,7 +2230,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
 dependencies = [
  "base64",
- "indexmap",
+ "indexmap 2.14.0",
  "quick-xml",
  "serde",
  "time",
@@ -1465,11 +2250,12 @@ checksum = "6a1395575e261a0c0dd2d360ac4e3b14a4c9f68647ee12e59d96af959e4c0f79"
 dependencies = [
  "bitvec",
  "delegate",
- "itertools",
+ "itertools 0.14.0",
  "num-traits",
+ "petgraph",
  "serde",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1497,6 +2283,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pretty"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d22152487193190344590e4f30e219cf3fe140d9e7a3fdb683d82aa2c5f4156"
+dependencies = [
+ "arrayvec",
+ "typed-arena",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1512,6 +2309,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "psl-types"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
+
+[[package]]
+name = "publicsuffix"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42ea446cab60335f76979ec15e12619a2165b5ae2c12166bef27d283a9fadf"
+dependencies = [
+ "idna",
+ "psl-types",
 ]
 
 [[package]]
@@ -1557,7 +2370,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1569,7 +2382,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1579,6 +2392,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand 0.10.2",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1610,12 +2480,33 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+dependencies = [
+ "rand_core 0.6.4",
+ "serde",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1625,7 +2516,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1638,12 +2538,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -1682,13 +2617,106 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
+name = "relrc"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c9d6253f1c4c3606b530b88ba15cd6803d4104ccd4d34173397ce49fe0b867"
+dependencies = [
+ "derive-where",
+ "derive_more 0.99.20",
+ "fxhash",
+ "itertools 0.13.0",
+ "petgraph",
+ "serde",
+ "slotmap_fork_lmondada",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64",
+ "bytes",
+ "cookie",
+ "cookie_store",
+ "encoding_rs",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "reqwest-websocket"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7705b649c3b66b85c4e9c304a6898b1ae3eecb880c474720ebf925e4a932ae02"
+dependencies = [
+ "async-tungstenite",
+ "bytes",
+ "futures-util",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "tungstenite 0.28.0",
+ "web-sys",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rsqlite-vfs"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
 dependencies = [
  "hashbrown 0.16.1",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1716,7 +2744,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn",
+ "syn 2.0.118",
  "unicode-ident",
 ]
 
@@ -1740,7 +2768,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn",
+ "syn 2.0.118",
  "walkdir",
 ]
 
@@ -1761,6 +2789,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1779,7 +2813,82 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+dependencies = [
+ "aws-lc-rs",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1804,6 +2913,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "scoped-futures"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1819,10 +2974,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "serde"
@@ -1851,7 +3033,18 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1861,7 +3054,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2f2d7ff8a2140333718bb329f5c40fc5f0865b84c426183ce14c97d2ab8154f"
 dependencies = [
  "form_urlencoded",
- "indexmap",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde_core",
@@ -1922,13 +3115,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
+dependencies = [
+ "base64",
+ "bs58",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.14.0",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -1939,7 +3164,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -1975,10 +3200,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "slotmap_fork_lmondada"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "936d3c60e7b845c8978d64485cffa451156294a772ebfafc0ea5fbd7a3c58669"
+dependencies = [
+ "serde",
+ "version_check",
+]
 
 [[package]]
 name = "smallvec"
@@ -1987,13 +3244,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
+name = "smol_str"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa7368fcf4852a4c2dd92df0cace6a71f2091ca0a23391ce7f3a31833f1523"
+dependencies = [
+ "borsh",
+ "serde_core",
+]
+
+[[package]]
 name = "socket2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2015,10 +3282,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "supports-color"
@@ -2053,10 +3353,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -2066,7 +3380,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2085,9 +3399,30 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "walkdir",
  "yaml-rust",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -2112,7 +3447,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2122,7 +3457,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2144,7 +3479,7 @@ checksum = "c26ef8b00e4d382e59f6a8ddb3cd790b3a5bb29f21a358a9a69ea2f29f13f27b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2153,7 +3488,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "944ad38adcbb71eaa682c56bceeb079e4ca82b4b3edc2a0fde5cb297b77dac8d"
 dependencies = [
- "syn",
+ "syn 2.0.118",
  "test-log-core",
 ]
 
@@ -2169,11 +3504,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2184,7 +3539,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2211,19 +3566,24 @@ dependencies = [
  "diesel-async",
  "diesel_migrations",
  "futures",
+ "hugr",
  "libsqlite3-sys",
  "miette",
+ "mockito",
  "num-complex",
  "portgraph",
  "pyo3",
  "regex",
+ "reqwest",
+ "reqwest-websocket",
  "rstest",
  "serde",
  "serde_json",
  "serde_plain",
+ "serde_with",
  "tempfile",
  "test-log",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tower-http",
  "tracing",
@@ -2277,6 +3637,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2285,11 +3660,12 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2300,7 +3676,17 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -2312,7 +3698,7 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite",
+ "tungstenite 0.29.0",
 ]
 
 [[package]]
@@ -2323,6 +3709,7 @@ checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",
@@ -2365,7 +3752,7 @@ version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "winnow 1.0.3",
@@ -2402,6 +3789,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
+ "async-compression",
  "bitflags",
  "bytes",
  "futures-core",
@@ -2417,8 +3805,10 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
+ "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -2453,7 +3843,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2496,6 +3886,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "sha1",
+ "thiserror 2.0.18",
+ "utf-8",
+]
+
+[[package]]
 name = "tungstenite"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2506,16 +3919,58 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand",
+ "rand 0.9.4",
  "sha1",
- "thiserror",
+ "thiserror 2.0.18",
 ]
+
+[[package]]
+name = "typed-arena"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "typetag"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c90e86058a30d42a1a928dfb4b49bb33c98c3a2b4909492e6b0881cd94798ec2"
+dependencies = [
+ "erased-serde",
+ "inventory",
+ "once_cell",
+ "serde",
+ "typetag-impl",
+]
+
+[[package]]
+name = "typetag-impl"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f153acc4e99a5f2a5aefa09fb078be54e26271b2813f6041200b224c098d8328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.2",
+]
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicase"
@@ -2536,6 +3991,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2548,6 +4009,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2558,6 +4031,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"
@@ -2577,7 +4056,7 @@ version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bde15df68e80b16c7d16b9616e80770ad158988daa56a27dccd1e55558b0160"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "serde",
  "serde_json",
  "utoipa-gen",
@@ -2605,7 +4084,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn",
+ "syn 2.0.118",
  "uuid",
 ]
 
@@ -2668,6 +4147,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2696,6 +4184,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2714,7 +4212,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
@@ -2725,6 +4223,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -2743,7 +4270,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2767,7 +4294,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2778,7 +4305,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2786,6 +4313,17 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
 
 [[package]]
 name = "windows-result"
@@ -2807,12 +4345,85 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
@@ -2878,7 +4489,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -2899,7 +4510,7 @@ checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2919,9 +4530,15 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"
@@ -2953,7 +4570,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2965,7 +4582,7 @@ dependencies = [
  "arbitrary",
  "crc32fast",
  "flate2",
- "indexmap",
+ "indexmap 2.14.0",
  "memchr",
  "zopfli",
 ]
@@ -2992,4 +4609,32 @@ dependencies = [
  "crc32fast",
  "log",
  "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/tierkreis/Cargo.toml
+++ b/tierkreis/Cargo.toml
@@ -47,7 +47,12 @@ utoipa-axum = { version = "0.2.0", features = ["debug"] }
 utoipa-swagger-ui = { version = "9.0.2", features = ["axum"] }
 uuid = { version = "1.23.0", features = ["serde", "v7"] }
 which = { version = "8.0.2", features = ["regex"] }
+reqwest = { version = "0.13.4", features = ["cookies", "gzip", "json", "query"] }
+serde_with = { version = "3.21.0", features = ["base64"] }
+hugr = "0.27.2"
+reqwest-websocket = { version = "0.6.0", features = ["json"] }
 
 [dev-dependencies]
+mockito = "1.7.2"
 rstest = "0.26.1"
 test-log = { version = "0.2.21", features = ["trace"] }

--- a/tierkreis/src/executor.rs
+++ b/tierkreis/src/executor.rs
@@ -4,6 +4,7 @@ as well as some utility functions and an [`ExecutorRegistry`] type.
 */
 pub mod inmemory;
 pub mod interface;
+pub mod nexus;
 pub mod subprocess;
 
 pub use crate::executor::inmemory::InMemoryExecutor;

--- a/tierkreis/src/executor/nexus.rs
+++ b/tierkreis/src/executor/nexus.rs
@@ -1,0 +1,6 @@
+/*!
+This module is a placeholder for a [`NexusExecutor`].
+*/
+
+#[allow(unused)]
+mod client;

--- a/tierkreis/src/executor/nexus/client.rs
+++ b/tierkreis/src/executor/nexus/client.rs
@@ -32,6 +32,12 @@ use crate::executor::nexus::client::models::{
     results::{QSysResult, QSysResultData},
 };
 
+const REFRESH_ENDPOINT: &str = "/auth/tokens/refresh";
+const PROJECTS_ENDPOINT: &str = "/api/projects/v1beta2";
+const HUGR_ENDPOINT: &str = "/api/hugr/v1beta";
+const JOBS_ENDPOINT: &str = "/api/jobs/v1beta3";
+const QSYS_RESULTS_PARTIAL_ENDPOINT: &str = "/api/qsys_results/v1beta2/partial";
+
 #[derive(Deserialize)]
 struct AccessToken {
     data: AccessTokenData,
@@ -164,6 +170,7 @@ pub struct NexusClient {
     http1_client: Client,
     client: Client,
     base_url: Url,
+    base_ws_url: Url,
 }
 
 impl NexusClient {
@@ -207,6 +214,9 @@ impl NexusClient {
             serde_json::from_str(&refresh_token_contents).into_diagnostic()?;
 
         let base_url: Url = format!("{scheme}://{host}").parse().into_diagnostic()?;
+        let mut base_ws_url: Url = base_url.clone();
+        base_ws_url.set_scheme("wss");
+
         let jar = Jar::default();
         jar.add_cookie_str(
             &format!("myqos_oat={}", refresh_token.data.refresh_token),
@@ -234,14 +244,12 @@ impl NexusClient {
             http1_client,
             client,
             base_url,
+            base_ws_url,
         })
     }
 
     pub async fn refresh_tokens(&self) -> miette::Result<()> {
-        let url = self
-            .base_url
-            .join("/auth/tokens/refresh")
-            .into_diagnostic()?;
+        let url = self.base_url.join(REFRESH_ENDPOINT).into_diagnostic()?;
         let response = self
             .client
             .post(url)
@@ -256,10 +264,7 @@ impl NexusClient {
     }
 
     pub async fn find_project_data(&self, name: &str) -> miette::Result<Option<Data>> {
-        let url = self
-            .base_url
-            .join("/api/projects/v1beta2")
-            .into_diagnostic()?;
+        let url = self.base_url.join(PROJECTS_ENDPOINT).into_diagnostic()?;
         let response = self
             .client
             .get(url)
@@ -280,10 +285,7 @@ impl NexusClient {
         name: &str,
         description: Option<&str>,
     ) -> miette::Result<Data> {
-        let url = self
-            .base_url
-            .join("/api/projects/v1beta2")
-            .into_diagnostic()?;
+        let url = self.base_url.join(PROJECTS_ENDPOINT).into_diagnostic()?;
         let response = self
             .client
             .post(url)
@@ -317,7 +319,7 @@ impl NexusClient {
         project_id: Uuid,
         package: Package,
     ) -> miette::Result<Data> {
-        let url = self.base_url.join("/api/hugr/v1beta").into_diagnostic()?;
+        let url = self.base_url.join(HUGR_ENDPOINT).into_diagnostic()?;
         let response = self
             .client
             .post(url)
@@ -338,7 +340,7 @@ impl NexusClient {
         project_id: Uuid,
         hugr_ids: impl IntoIterator<Item = (Uuid, u64)>,
     ) -> miette::Result<Data> {
-        let url = self.base_url.join("/api/jobs/v1beta3").into_diagnostic()?;
+        let url = self.base_url.join(JOBS_ENDPOINT).into_diagnostic()?;
         let items: Vec<_> = hugr_ids
             .into_iter()
             .map(|(hugr_id, n_shots)| NewExecuteJobItem::new(hugr_id, n_shots))
@@ -365,8 +367,8 @@ impl NexusClient {
     pub async fn get_job(&self, job_id: Uuid) -> miette::Result<JobData> {
         let url = self
             .base_url
-            .join("/api/jobs/v1beta3/")
-            .and_then(|url| url.join(&job_id.to_string()))
+            .join(JOBS_ENDPOINT)
+            .and_then(|url| url.join(&format!("/{job_id}")))
             .into_diagnostic()?;
         let response = self.client.get(url).send().await.into_diagnostic()?;
 
@@ -376,11 +378,16 @@ impl NexusClient {
     }
 
     pub async fn listen_for_job_status(&self, job_id: Uuid) -> miette::Result<JobStatusStream> {
+        let url = self
+            .base_ws_url
+            .join(JOBS_ENDPOINT)
+            .and_then(|url| url.join(&format!("/{job_id}/")))
+            .and_then(|url| url.join("/attributes/status/ws"))
+            .into_diagnostic()?;
+
         let response = self
             .http1_client
-            .get(format!(
-                "wss://nexus.quantinuum.com/api/jobs/v1beta3/{job_id}/attributes/status/ws"
-            ))
+            .get(url)
             .upgrade()
             .send()
             .await
@@ -397,8 +404,8 @@ impl NexusClient {
     ) -> miette::Result<QSysResultData> {
         let url = self
             .base_url
-            .join("/api/qsys_results/v1beta2/partial/")
-            .and_then(|url| url.join(&result_id.to_string()))
+            .join(QSYS_RESULTS_PARTIAL_ENDPOINT)
+            .and_then(|url| url.join(&format!("/{result_id}")))
             .into_diagnostic()?;
         let response = self
             .client

--- a/tierkreis/src/executor/nexus/client.rs
+++ b/tierkreis/src/executor/nexus/client.rs
@@ -2,7 +2,6 @@ pub(crate) mod models;
 
 use std::{
     env::home_dir,
-    fmt::Display,
     path::{Path, PathBuf},
     pin::Pin,
     sync::Arc,
@@ -104,16 +103,13 @@ impl Stream for JobStatusStream {
             Poll::Ready(Some(Ok(Message::Binary(bin)))) => {
                 Poll::Ready(Some(serde_json::from_slice(&bin).into_diagnostic()))
             }
-            // Ignoring ping messages may be sub-optimal, we may want to have a way to send
-            // pong responses but this would require another channel and a bit more
-            // engineering effort.
-            Poll::Ready(Some(Ok(Message::Ping(_)))) => {
-                cx.waker().wake_by_ref();
-                Poll::Pending
-            }
             // We are ignoring pong messages we receive, which seems reasonable to
             // abstract over as there are no further actions to take.
-            Poll::Ready(Some(Ok(Message::Pong(_)))) => {
+            //
+            // Ignoring ping messages may be sub-optimal, we may want to have a way to send
+            // pong responses but this would require another channel and a bit more
+            // engineering effort for the current design.
+            Poll::Ready(Some(Ok(Message::Pong(_) | Message::Ping(_)))) => {
                 cx.waker().wake_by_ref();
                 Poll::Pending
             }
@@ -149,16 +145,26 @@ impl JobStatusStream {
     }
 }
 
-pub enum Scheme {
-    Http,
-    Https,
+pub enum TLSMode {
+    #[cfg(test)]
+    None,
+    Default,
 }
 
-impl Display for Scheme {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl TLSMode {
+    fn http_scheme(&self) -> &'static str {
         match self {
-            Self::Http => write!(f, "http"),
-            Self::Https => write!(f, "https"),
+            #[cfg(test)]
+            Self::None => "http",
+            Self::Default => "https",
+        }
+    }
+
+    fn ws_scheme(&self) -> &'static str {
+        match self {
+            #[cfg(test)]
+            Self::None => "ws",
+            Self::Default => "wss",
         }
     }
 }
@@ -175,7 +181,7 @@ pub struct NexusClient {
 
 impl NexusClient {
     pub async fn try_new(
-        scheme: Scheme,
+        tls_mode: TLSMode,
         host: Host,
         token_dir: Option<&Path>,
     ) -> miette::Result<Self> {
@@ -213,9 +219,13 @@ impl NexusClient {
         let refresh_token: RefreshToken =
             serde_json::from_str(&refresh_token_contents).into_diagnostic()?;
 
-        let base_url: Url = format!("{scheme}://{host}").parse().into_diagnostic()?;
+        let base_url: Url = format!("{}://{host}", tls_mode.http_scheme())
+            .parse()
+            .into_diagnostic()?;
         let mut base_ws_url: Url = base_url.clone();
-        base_ws_url.set_scheme("wss");
+        base_ws_url
+            .set_scheme(tls_mode.ws_scheme())
+            .map_err(|()| miette!("Failed to set websocket scheme"))?;
 
         let jar = Jar::default();
         jar.add_cookie_str(
@@ -367,9 +377,9 @@ impl NexusClient {
     pub async fn get_job(&self, job_id: Uuid) -> miette::Result<JobData> {
         let url = self
             .base_url
-            .join(JOBS_ENDPOINT)
-            .and_then(|url| url.join(&format!("/{job_id}")))
+            .join(&format!("{JOBS_ENDPOINT}/{job_id}"))
             .into_diagnostic()?;
+
         let response = self.client.get(url).send().await.into_diagnostic()?;
 
         response.error_for_status_ref().into_diagnostic()?;
@@ -380,9 +390,7 @@ impl NexusClient {
     pub async fn listen_for_job_status(&self, job_id: Uuid) -> miette::Result<JobStatusStream> {
         let url = self
             .base_ws_url
-            .join(JOBS_ENDPOINT)
-            .and_then(|url| url.join(&format!("/{job_id}/")))
-            .and_then(|url| url.join("/attributes/status/ws"))
+            .join(&format!("{JOBS_ENDPOINT}/{job_id}/attributes/status/ws"))
             .into_diagnostic()?;
 
         let response = self
@@ -393,6 +401,7 @@ impl NexusClient {
             .await
             .into_diagnostic()?;
 
+        response.error_for_status_ref().into_diagnostic()?;
         let websocket = response.into_websocket().await.into_diagnostic()?;
         Ok(JobStatusStream::new(websocket))
     }
@@ -404,8 +413,7 @@ impl NexusClient {
     ) -> miette::Result<QSysResultData> {
         let url = self
             .base_url
-            .join(QSYS_RESULTS_PARTIAL_ENDPOINT)
-            .and_then(|url| url.join(&format!("/{result_id}")))
+            .join(&format!("{QSYS_RESULTS_PARTIAL_ENDPOINT}/{result_id}"))
             .into_diagnostic()?;
         let response = self
             .client
@@ -472,7 +480,7 @@ mod tests {
             )
             .create();
 
-        let client = NexusClient::try_new(Scheme::Http, host, Some(token_path)).await?;
+        let client = NexusClient::try_new(TLSMode::None, host, Some(token_path)).await?;
         client.refresh_tokens().await?;
 
         mock.assert_async().await;
@@ -493,7 +501,7 @@ mod tests {
             .with_status(401)
             .create();
 
-        let client = NexusClient::try_new(Scheme::Http, host, Some(token_path)).await?;
+        let client = NexusClient::try_new(TLSMode::None, host, Some(token_path)).await?;
         let err = client.refresh_tokens().await.unwrap_err();
         assert!(
             err.to_string()
@@ -519,7 +527,7 @@ mod tests {
             .with_body("{\"data\": [{\"id\": \"ebdc7a71-45d7-4a8f-b175-1361903a760b\"}]}")
             .create();
 
-        let client = NexusClient::try_new(Scheme::Http, host, Some(token_path)).await?;
+        let client = NexusClient::try_new(TLSMode::None, host, Some(token_path)).await?;
         let project_data = client
             .find_or_create_project_data("foo", Some("description"))
             .await?;
@@ -568,7 +576,7 @@ mod tests {
             ))
             .create();
 
-        let client = NexusClient::try_new(Scheme::Http, host, Some(token_path)).await?;
+        let client = NexusClient::try_new(TLSMode::None, host, Some(token_path)).await?;
         let project_data = client
             .find_or_create_project_data("foo", Some("description"))
             .await?;

--- a/tierkreis/src/executor/nexus/client.rs
+++ b/tierkreis/src/executor/nexus/client.rs
@@ -1,0 +1,486 @@
+pub(crate) mod models;
+
+use std::{
+    env::home_dir,
+    path::{Path, PathBuf},
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+use diesel::AggregateExpressionMethods;
+use futures::{Stream, StreamExt};
+use hugr::package::Package;
+use miette::{IntoDiagnostic, miette};
+use reqwest::{
+    Client, ClientBuilder,
+    cookie::{CookieStore, Jar},
+};
+use reqwest_websocket::Upgrade;
+use serde::Deserialize;
+use tokio::{fs::File, io::AsyncReadExt};
+use url::{Host, Url};
+use uuid::Uuid;
+
+use crate::executor::nexus::client::models::{
+    CollectionDocument, Data, Document, NewExecuteJobItem, NewHugr, NewJob, NewJobDefinition,
+    NewProject,
+    jobs::{Job, JobData, Status},
+    results::{QSysResult, QSysResultData},
+};
+
+#[derive(Deserialize)]
+struct AccessToken {
+    data: AccessTokenData,
+}
+
+#[derive(Deserialize)]
+struct AccessTokenData {
+    access_token: String,
+}
+
+#[derive(Deserialize)]
+struct RefreshToken {
+    data: RefreshTokenData,
+}
+
+#[derive(Deserialize)]
+struct RefreshTokenData {
+    #[allow(unused)]
+    delete_version_after: Option<String>,
+    refresh_token: String,
+}
+
+pub struct JobStatusStream {
+    websocket: reqwest_websocket::WebSocket,
+}
+
+impl Stream for JobStatusStream {
+    type Item = miette::Result<Status>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.get_mut().websocket.poll_next_unpin(cx).map(|next| {
+            next.map(|res| {
+                let message = res.into_diagnostic()?;
+                message.json().into_diagnostic()
+            })
+        })
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.websocket.size_hint()
+    }
+}
+
+impl JobStatusStream {
+    pub async fn close(self) -> miette::Result<()> {
+        self.websocket
+            .close(reqwest_websocket::CloseCode::Normal, None)
+            .await
+            .into_diagnostic()?;
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+pub struct NexusClient {
+    client: Client,
+    base_url: Url,
+}
+
+impl NexusClient {
+    pub async fn try_new(host: Host, token_dir: Option<&Path>) -> miette::Result<Self> {
+        // Assumes that a user has credentials saved from qnexus in their home directory.
+        //
+        // While we could replicate the device code login flow here, this is much easier
+        // for getting something running in the short term.
+        let token_dir_path = token_dir.map_or_else(
+            || -> miette::Result<PathBuf> {
+                let home_dir_path = home_dir().ok_or_else(|| miette!("no home directory"))?;
+                let token_dir_path = home_dir_path.join(".qnx/auth");
+                Ok(token_dir_path)
+            },
+            |path| Ok(path.to_path_buf()),
+        )?;
+        let access_token_path = token_dir_path.join("id.json");
+        let refresh_token_path = token_dir_path.join("token.json");
+
+        let mut access_token_file = File::open(access_token_path).await.into_diagnostic()?;
+        let mut refresh_token_file = File::open(refresh_token_path).await.into_diagnostic()?;
+
+        let mut access_token_contents = String::new();
+        access_token_file
+            .read_to_string(&mut access_token_contents)
+            .await
+            .into_diagnostic()?;
+        let access_token: AccessToken =
+            serde_json::from_str(&access_token_contents).into_diagnostic()?;
+
+        let mut refresh_token_contents = String::new();
+        refresh_token_file
+            .read_to_string(&mut refresh_token_contents)
+            .await
+            .into_diagnostic()?;
+        let refresh_token: RefreshToken =
+            serde_json::from_str(&refresh_token_contents).into_diagnostic()?;
+
+        let base_url: Url = format!("http://{host}").parse().into_diagnostic()?;
+        let jar = Jar::default();
+        jar.add_cookie_str(
+            &format!("myqos_oat={}", refresh_token.data.refresh_token),
+            &base_url,
+        );
+        jar.add_cookie_str(
+            &format!("myqos_id={}", access_token.data.access_token),
+            &base_url,
+        );
+
+        let client = ClientBuilder::new()
+            .cookie_provider(Arc::new(jar))
+            .http1_only() // See https://github.com/jgraef/reqwest-websocket/issues/2
+            .build()
+            .into_diagnostic()?;
+
+        Ok(Self { client, base_url })
+    }
+
+    pub async fn refresh_tokens(&self) -> miette::Result<()> {
+        let url = self
+            .base_url
+            .join("/auth/tokens/refresh")
+            .into_diagnostic()?;
+        let response = self
+            .client
+            .post(url)
+            .header("Content-Type", "application/json")
+            .send()
+            .await
+            .into_diagnostic()?;
+
+        response.error_for_status_ref().into_diagnostic()?;
+
+        Ok(())
+    }
+
+    pub async fn find_project_data(&self, name: &str) -> miette::Result<Option<Data>> {
+        let url = self
+            .base_url
+            .join("/api/projects/v1beta2")
+            .into_diagnostic()?;
+        let response = self
+            .client
+            .get(url)
+            .query(&[("filter[name_exact]", name)])
+            .send()
+            .await
+            .into_diagnostic()?;
+
+        response.error_for_status_ref().into_diagnostic()?;
+        let projects: CollectionDocument = response.json().await.into_diagnostic()?;
+
+        // We expect exactly one element
+        Ok(projects.last_data())
+    }
+
+    pub async fn new_project_data(
+        &self,
+        name: &str,
+        description: Option<&str>,
+    ) -> miette::Result<Data> {
+        let url = self
+            .base_url
+            .join("/api/projects/v1beta2")
+            .into_diagnostic()?;
+        let response = self
+            .client
+            .post(url)
+            .json(&NewProject::new(name, description))
+            .send()
+            .await
+            .into_diagnostic()?;
+
+        response.error_for_status_ref().into_diagnostic()?;
+        let project: Document = response.json().await.into_diagnostic()?;
+        Ok(project.data())
+    }
+
+    pub async fn find_or_create_project_data(
+        &self,
+        name: &str,
+        description: Option<&str>,
+    ) -> miette::Result<Data> {
+        let project_data = self.find_project_data(name).await?;
+        if let Some(project_data) = project_data {
+            Ok(project_data)
+        } else {
+            self.new_project_data(name, description).await
+        }
+    }
+
+    pub async fn new_hugr_data(
+        &self,
+        name: &str,
+        description: Option<&str>,
+        project_id: Uuid,
+        package: Package,
+    ) -> miette::Result<Data> {
+        let url = self.base_url.join("/api/hugr/v1beta").into_diagnostic()?;
+        let response = self
+            .client
+            .post(url)
+            .json(&NewHugr::new(name, description, project_id, package))
+            .send()
+            .await
+            .into_diagnostic()?;
+
+        response.error_for_status_ref().into_diagnostic()?;
+        let hugr: Document = response.json().await.into_diagnostic()?;
+        Ok(hugr.data())
+    }
+
+    pub async fn new_job_data(
+        &self,
+        name: &str,
+        description: Option<&str>,
+        project_id: Uuid,
+        hugr_ids: impl IntoIterator<Item = (Uuid, u64)>,
+    ) -> miette::Result<Data> {
+        let url = self.base_url.join("/api/jobs/v1beta3").into_diagnostic()?;
+        let items: Vec<_> = hugr_ids
+            .into_iter()
+            .map(|(hugr_id, n_shots)| NewExecuteJobItem::new(hugr_id, n_shots))
+            .collect();
+
+        let response = self
+            .client
+            .post(url)
+            .json(&NewJob::new(
+                name,
+                description,
+                project_id,
+                NewJobDefinition::new_execute(&items),
+            ))
+            .send()
+            .await
+            .into_diagnostic()?;
+
+        response.error_for_status_ref().into_diagnostic()?;
+        let job: Document = response.json().await.into_diagnostic()?;
+        Ok(job.data())
+    }
+
+    pub async fn get_job(&self, job_id: Uuid) -> miette::Result<JobData> {
+        let url = self
+            .base_url
+            .join("/api/jobs/v1beta3/")
+            .and_then(|url| url.join(&job_id.to_string()))
+            .into_diagnostic()?;
+        let response = self.client.get(url).send().await.into_diagnostic()?;
+
+        response.error_for_status_ref().into_diagnostic()?;
+        let job: Job = response.json().await.into_diagnostic()?;
+        Ok(job.data())
+    }
+
+    pub async fn listen_for_job_status(&self, job_id: Uuid) -> miette::Result<JobStatusStream> {
+        let response = self
+            .client
+            .get(format!(
+                "wss://nexus.quantinuum.com/api/jobs/v1beta3/{job_id}/attributes/status/ws"
+            ))
+            .upgrade()
+            .send()
+            .await
+            .into_diagnostic()?;
+
+        let websocket = response.into_websocket().await.into_diagnostic()?;
+        Ok(JobStatusStream { websocket })
+    }
+
+    pub async fn get_qsys_result_chunk(
+        &self,
+        result_id: Uuid,
+        chunk_number: u32,
+    ) -> miette::Result<QSysResultData> {
+        let url = self
+            .base_url
+            .join("/api/qsys_results/v1beta2/partial/")
+            .and_then(|url| url.join(&result_id.to_string()))
+            .into_diagnostic()?;
+        let response = self
+            .client
+            .get(url)
+            .query(&[("chunk_number", chunk_number)])
+            .send()
+            .await
+            .into_diagnostic()?;
+
+        response.error_for_status_ref().into_diagnostic()?;
+        let result: QSysResult = response.json().await.into_diagnostic()?;
+        Ok(result.data())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use mockito::Matcher::{AnyOf, PartialJsonString};
+    use tempfile::{TempDir, env::temp_dir, tempdir};
+    use tokio::io::AsyncWriteExt;
+
+    use super::*;
+
+    async fn setup_temp_tokens() -> miette::Result<TempDir> {
+        let token_dir = tempdir().into_diagnostic()?;
+        let token_dir_path = token_dir.path();
+
+        let access_token_path = token_dir_path.join("id.json");
+        let refresh_token_path = token_dir_path.join("token.json");
+
+        let mut access_token_file = File::create(access_token_path).await.into_diagnostic()?;
+        access_token_file
+            .write_all(b"{\"data\": {\"access_token\": \"YWJj\"}}")
+            .await
+            .into_diagnostic()?;
+
+        let mut refresh_token_file = File::create(refresh_token_path).await.into_diagnostic()?;
+        refresh_token_file
+            .write_all(b"{\"data\": {\"refresh_token\": \"Y2Jh\"}}")
+            .await
+            .into_diagnostic()?;
+
+        Ok(token_dir)
+    }
+
+    #[tokio::test]
+    async fn refresh_tokens() -> miette::Result<()> {
+        let token_dir = setup_temp_tokens().await?;
+        let token_path = token_dir.path();
+
+        let mut server = mockito::Server::new_async().await;
+        let host = Host::Domain(server.host_with_port());
+
+        let mock = server
+            .mock("POST", "/auth/tokens/refresh")
+            .with_status(201)
+            // Ordering is semi-random from the jar storage.
+            .match_header(
+                "Cookie",
+                AnyOf(vec![
+                    "myqos_oat=Y2Jh; myqos_id=YWJj".into(),
+                    "myqos_id=YWJj; myqos_oat=Y2Jh".into(),
+                ]),
+            )
+            .create();
+
+        let client = NexusClient::try_new(host, Some(token_path)).await?;
+        client.refresh_tokens().await?;
+
+        mock.assert_async().await;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn refresh_tokens_error() -> miette::Result<()> {
+        let token_dir = setup_temp_tokens().await?;
+        let token_path = token_dir.path();
+
+        let mut server = mockito::Server::new_async().await;
+        let host = Host::Domain(server.host_with_port());
+
+        let mock = server
+            .mock("POST", "/auth/tokens/refresh")
+            .with_status(401)
+            .create();
+
+        let client = NexusClient::try_new(host, Some(token_path)).await?;
+        let err = client.refresh_tokens().await.unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("HTTP status client error (401 Unauthorized)")
+        );
+
+        mock.assert_async().await;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn find_or_create_project_find() -> miette::Result<()> {
+        let token_dir = setup_temp_tokens().await?;
+        let token_path = token_dir.path();
+
+        let mut server = mockito::Server::new_async().await;
+        let host = Host::Domain(server.host_with_port());
+
+        let mock = server
+            .mock("GET", "/api/projects/v1beta2?filter%5Bname_exact%5D=foo")
+            .with_status(200)
+            .with_body("{\"data\": [{\"id\": \"ebdc7a71-45d7-4a8f-b175-1361903a760b\"}]}")
+            .create();
+
+        let client = NexusClient::try_new(host, Some(token_path)).await?;
+        let project_data = client
+            .find_or_create_project_data("foo", Some("description"))
+            .await?;
+
+        assert_eq!(
+            project_data.id().to_string(),
+            "ebdc7a71-45d7-4a8f-b175-1361903a760b"
+        );
+
+        mock.assert_async().await;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn find_or_create_project_create() -> miette::Result<()> {
+        let token_dir = setup_temp_tokens().await?;
+        let token_path = token_dir.path();
+
+        let mut server = mockito::Server::new_async().await;
+        let host = Host::Domain(server.host_with_port());
+
+        let mock1 = server
+            .mock("GET", "/api/projects/v1beta2?filter%5Bname_exact%5D=foo")
+            .with_status(200)
+            .with_body("{\"data\": []}")
+            .create();
+
+        let mock2 = server
+            .mock("POST", "/api/projects/v1beta2")
+            .with_status(201)
+            .with_body("{\"data\": {\"id\": \"ebdc7a71-45d7-4a8f-b175-1361903a760b\"}}")
+            .match_body(PartialJsonString(
+                "{
+                    \"data\": {
+                        \"attributes\": {
+                            \"name\": \"foo\",
+                            \"description\": \"description\",
+                            \"properties\": {}
+                        },
+                        \"relationships\": {},
+                        \"type\": \"project\"
+                    }
+                }"
+                .to_string(),
+            ))
+            .create();
+
+        let client = NexusClient::try_new(host, Some(token_path)).await?;
+        let project_data = client
+            .find_or_create_project_data("foo", Some("description"))
+            .await?;
+
+        assert_eq!(
+            project_data.id().to_string(),
+            "ebdc7a71-45d7-4a8f-b175-1361903a760b"
+        );
+
+        mock1.assert_async().await;
+        mock2.assert_async().await;
+
+        Ok(())
+    }
+}

--- a/tierkreis/src/executor/nexus/client.rs
+++ b/tierkreis/src/executor/nexus/client.rs
@@ -2,23 +2,26 @@ pub(crate) mod models;
 
 use std::{
     env::home_dir,
+    fmt::Display,
     path::{Path, PathBuf},
     pin::Pin,
     sync::Arc,
     task::{Context, Poll},
+    time::Duration,
 };
 
-use diesel::AggregateExpressionMethods;
-use futures::{Stream, StreamExt};
+use futures::{
+    SinkExt, Stream, StreamExt,
+    channel::mpsc,
+    stream::{SplitSink, SplitStream},
+};
 use hugr::package::Package;
 use miette::{IntoDiagnostic, miette};
-use reqwest::{
-    Client, ClientBuilder,
-    cookie::{CookieStore, Jar},
-};
-use reqwest_websocket::Upgrade;
+use reqwest::{Client, ClientBuilder, cookie::Jar};
+use reqwest_websocket::{Bytes, Message, Upgrade};
 use serde::Deserialize;
-use tokio::{fs::File, io::AsyncReadExt};
+use tokio::{fs::File, io::AsyncReadExt, task::JoinHandle};
+use tracing::warn;
 use url::{Host, Url};
 use uuid::Uuid;
 
@@ -52,29 +55,87 @@ struct RefreshTokenData {
 }
 
 pub struct JobStatusStream {
-    websocket: reqwest_websocket::WebSocket,
+    stream: SplitStream<reqwest_websocket::WebSocket>,
+    join_handle: JoinHandle<miette::Result<SplitSink<reqwest_websocket::WebSocket, Message>>>,
+    close_sender: mpsc::Sender<()>,
+}
+
+impl JobStatusStream {
+    fn new(websocket: reqwest_websocket::WebSocket) -> Self {
+        let (mut sink, stream) = websocket.split();
+        let (close_sender, mut close_receiver) = mpsc::channel(1);
+        let join_handle = tokio::spawn(async move {
+            let mut interval = tokio::time::interval(Duration::from_secs(55));
+            loop {
+                tokio::select! {
+                    _ = close_receiver.recv() => {
+                        return Ok(sink)
+                    }
+                    _ = interval.tick() => {
+                        sink.send(reqwest_websocket::Message::Ping(Bytes::new()))
+                            .await.into_diagnostic()?;
+                    }
+                }
+            }
+        });
+        Self {
+            stream,
+            join_handle,
+            close_sender,
+        }
+    }
 }
 
 impl Stream for JobStatusStream {
     type Item = miette::Result<Status>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        self.get_mut().websocket.poll_next_unpin(cx).map(|next| {
-            next.map(|res| {
-                let message = res.into_diagnostic()?;
-                message.json().into_diagnostic()
-            })
-        })
+        let next = self.get_mut().stream.poll_next_unpin(cx);
+        match next {
+            Poll::Ready(Some(Ok(Message::Text(text)))) => {
+                Poll::Ready(Some(serde_json::from_str(&text).into_diagnostic()))
+            }
+            Poll::Ready(Some(Ok(Message::Binary(bin)))) => {
+                Poll::Ready(Some(serde_json::from_slice(&bin).into_diagnostic()))
+            }
+            // Ignoring ping messages may be sub-optimal, we may want to have a way to send
+            // pong responses but this would require another channel and a bit more
+            // engineering effort.
+            Poll::Ready(Some(Ok(Message::Ping(_)))) => {
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            }
+            // We are ignoring pong messages we receive, which seems reasonable to
+            // abstract over as there are no further actions to take.
+            Poll::Ready(Some(Ok(Message::Pong(_)))) => {
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            }
+            // We may want to reconnect in this case, but that is a decision for the consumer
+            // of this stream to make.
+            Poll::Ready(Some(Ok(Message::Close { code, reason }))) => {
+                warn!("Websocket closed by peer with code: {code}, reason: {reason}");
+                Poll::Ready(None)
+            }
+            Poll::Ready(Some(Err(err))) => {
+                Poll::Ready(Some(Err(miette!("Websocket error: {err}"))))
+            }
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Pending => Poll::Pending,
+        }
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        self.websocket.size_hint()
+        self.stream.size_hint()
     }
 }
 
 impl JobStatusStream {
-    pub async fn close(self) -> miette::Result<()> {
-        self.websocket
+    pub async fn close(mut self) -> miette::Result<()> {
+        self.close_sender.send(()).await.into_diagnostic()?;
+        let sink = self.join_handle.await.into_diagnostic()??;
+        let websocket = self.stream.reunite(sink).into_diagnostic()?;
+        websocket
             .close(reqwest_websocket::CloseCode::Normal, None)
             .await
             .into_diagnostic()?;
@@ -82,14 +143,35 @@ impl JobStatusStream {
     }
 }
 
+pub enum Scheme {
+    Http,
+    Https,
+}
+
+impl Display for Scheme {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Http => write!(f, "http"),
+            Self::Https => write!(f, "https"),
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct NexusClient {
+    // See https://github.com/jgraef/reqwest-websocket/issues/2
+    // for why we need a separate Client instance for websockets.
+    http1_client: Client,
     client: Client,
     base_url: Url,
 }
 
 impl NexusClient {
-    pub async fn try_new(host: Host, token_dir: Option<&Path>) -> miette::Result<Self> {
+    pub async fn try_new(
+        scheme: Scheme,
+        host: Host,
+        token_dir: Option<&Path>,
+    ) -> miette::Result<Self> {
         // Assumes that a user has credentials saved from qnexus in their home directory.
         //
         // While we could replicate the device code login flow here, this is much easier
@@ -124,7 +206,7 @@ impl NexusClient {
         let refresh_token: RefreshToken =
             serde_json::from_str(&refresh_token_contents).into_diagnostic()?;
 
-        let base_url: Url = format!("http://{host}").parse().into_diagnostic()?;
+        let base_url: Url = format!("{scheme}://{host}").parse().into_diagnostic()?;
         let jar = Jar::default();
         jar.add_cookie_str(
             &format!("myqos_oat={}", refresh_token.data.refresh_token),
@@ -135,13 +217,24 @@ impl NexusClient {
             &base_url,
         );
 
-        let client = ClientBuilder::new()
-            .cookie_provider(Arc::new(jar))
+        let jar = Arc::new(jar);
+
+        let http1_client = ClientBuilder::new()
+            .cookie_provider(Arc::clone(&jar))
             .http1_only() // See https://github.com/jgraef/reqwest-websocket/issues/2
             .build()
             .into_diagnostic()?;
 
-        Ok(Self { client, base_url })
+        let client = ClientBuilder::new()
+            .cookie_provider(jar)
+            .build()
+            .into_diagnostic()?;
+
+        Ok(Self {
+            http1_client,
+            client,
+            base_url,
+        })
     }
 
     pub async fn refresh_tokens(&self) -> miette::Result<()> {
@@ -284,7 +377,7 @@ impl NexusClient {
 
     pub async fn listen_for_job_status(&self, job_id: Uuid) -> miette::Result<JobStatusStream> {
         let response = self
-            .client
+            .http1_client
             .get(format!(
                 "wss://nexus.quantinuum.com/api/jobs/v1beta3/{job_id}/attributes/status/ws"
             ))
@@ -294,7 +387,7 @@ impl NexusClient {
             .into_diagnostic()?;
 
         let websocket = response.into_websocket().await.into_diagnostic()?;
-        Ok(JobStatusStream { websocket })
+        Ok(JobStatusStream::new(websocket))
     }
 
     pub async fn get_qsys_result_chunk(
@@ -324,7 +417,7 @@ impl NexusClient {
 #[cfg(test)]
 mod tests {
     use mockito::Matcher::{AnyOf, PartialJsonString};
-    use tempfile::{TempDir, env::temp_dir, tempdir};
+    use tempfile::{TempDir, tempdir};
     use tokio::io::AsyncWriteExt;
 
     use super::*;
@@ -372,7 +465,7 @@ mod tests {
             )
             .create();
 
-        let client = NexusClient::try_new(host, Some(token_path)).await?;
+        let client = NexusClient::try_new(Scheme::Http, host, Some(token_path)).await?;
         client.refresh_tokens().await?;
 
         mock.assert_async().await;
@@ -393,7 +486,7 @@ mod tests {
             .with_status(401)
             .create();
 
-        let client = NexusClient::try_new(host, Some(token_path)).await?;
+        let client = NexusClient::try_new(Scheme::Http, host, Some(token_path)).await?;
         let err = client.refresh_tokens().await.unwrap_err();
         assert!(
             err.to_string()
@@ -419,7 +512,7 @@ mod tests {
             .with_body("{\"data\": [{\"id\": \"ebdc7a71-45d7-4a8f-b175-1361903a760b\"}]}")
             .create();
 
-        let client = NexusClient::try_new(host, Some(token_path)).await?;
+        let client = NexusClient::try_new(Scheme::Http, host, Some(token_path)).await?;
         let project_data = client
             .find_or_create_project_data("foo", Some("description"))
             .await?;
@@ -468,7 +561,7 @@ mod tests {
             ))
             .create();
 
-        let client = NexusClient::try_new(host, Some(token_path)).await?;
+        let client = NexusClient::try_new(Scheme::Http, host, Some(token_path)).await?;
         let project_data = client
             .find_or_create_project_data("foo", Some("description"))
             .await?;

--- a/tierkreis/src/executor/nexus/client/models.rs
+++ b/tierkreis/src/executor/nexus/client/models.rs
@@ -1,0 +1,10 @@
+pub mod generic;
+pub mod hugr;
+pub mod jobs;
+pub mod projects;
+pub mod results;
+
+pub use generic::{CollectionDocument, Data, Document, NewRelationship};
+pub use hugr::NewHugr;
+pub use jobs::{NewExecuteJobItem, NewJob, NewJobDefinition};
+pub use projects::NewProject;

--- a/tierkreis/src/executor/nexus/client/models/generic.rs
+++ b/tierkreis/src/executor/nexus/client/models/generic.rs
@@ -1,0 +1,54 @@
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Debug, Serialize)]
+pub struct NewRelationshipData {
+    id: Uuid,
+    r#type: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+pub struct NewRelationship {
+    data: NewRelationshipData,
+}
+
+impl NewRelationship {
+    pub fn new(id: Uuid, r#type: &'static str) -> Self {
+        NewRelationship {
+            data: NewRelationshipData { id, r#type },
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Data {
+    id: Uuid,
+}
+
+impl Data {
+    pub fn id(&self) -> Uuid {
+        self.id
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CollectionDocument {
+    data: Vec<Data>,
+}
+
+impl CollectionDocument {
+    pub fn last_data(mut self) -> Option<Data> {
+        self.data.pop()
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Document {
+    data: Data,
+}
+
+impl Document {
+    pub fn data(self) -> Data {
+        self.data
+    }
+}

--- a/tierkreis/src/executor/nexus/client/models/hugr.rs
+++ b/tierkreis/src/executor/nexus/client/models/hugr.rs
@@ -1,0 +1,66 @@
+use hugr::{envelope::serde_with::AsBinaryEnvelope, package::Package};
+use serde::Serialize;
+use serde_with::serde_as;
+use uuid::Uuid;
+
+use crate::executor::nexus::client::models::NewRelationship;
+
+#[derive(Serialize)]
+struct NewHugrRelationships {
+    project: NewRelationship,
+}
+
+impl NewHugrRelationships {
+    pub fn new(project_id: Uuid) -> Self {
+        Self {
+            project: NewRelationship::new(project_id, "project"),
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct HugrProperties {}
+
+#[serde_as]
+#[derive(Serialize)]
+struct NewHugrAttributes<'a> {
+    name: &'a str,
+    description: Option<&'a str>,
+    properties: HugrProperties,
+    #[serde_as(as = "AsBinaryEnvelope")]
+    contents: Package,
+}
+
+#[derive(Serialize)]
+struct NewHugrData<'a> {
+    attributes: NewHugrAttributes<'a>,
+    relationships: NewHugrRelationships,
+    r#type: &'static str,
+}
+
+#[derive(Serialize)]
+pub struct NewHugr<'a> {
+    data: NewHugrData<'a>,
+}
+
+impl NewHugr<'_> {
+    pub fn new<'a>(
+        name: &'a str,
+        description: Option<&'a str>,
+        project_id: Uuid,
+        package: Package,
+    ) -> NewHugr<'a> {
+        NewHugr {
+            data: NewHugrData {
+                attributes: NewHugrAttributes {
+                    name,
+                    description,
+                    properties: HugrProperties {},
+                    contents: package,
+                },
+                relationships: NewHugrRelationships::new(project_id),
+                r#type: "hugr",
+            },
+        }
+    }
+}

--- a/tierkreis/src/executor/nexus/client/models/jobs.rs
+++ b/tierkreis/src/executor/nexus/client/models/jobs.rs
@@ -1,0 +1,196 @@
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::executor::nexus::client::models::NewRelationship;
+
+#[derive(Debug, Serialize)]
+struct NewJobRelationships {
+    project: NewRelationship,
+}
+
+impl NewJobRelationships {
+    pub fn new(project_id: Uuid) -> Self {
+        Self {
+            project: NewRelationship::new(project_id, "project"),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct JobProperties {}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "type")]
+pub enum NewBackendConfig {
+    SeleneConfig {},
+}
+
+impl NewBackendConfig {
+    fn selene() -> NewBackendConfig {
+        NewBackendConfig::SeleneConfig {}
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct NewExecuteJobItem {
+    program_id: Uuid,
+    n_shots: u64,
+    n_qubits: u64,
+}
+
+impl NewExecuteJobItem {
+    pub fn new(program_id: Uuid, n_shots: u64) -> Self {
+        NewExecuteJobItem {
+            program_id,
+            n_shots,
+            n_qubits: 20,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "job_definition_type")]
+#[serde(rename_all = "snake_case")]
+pub enum NewJobDefinition<'a> {
+    ExecuteJobDefinition {
+        backend_config: NewBackendConfig,
+        items: &'a [NewExecuteJobItem],
+    },
+}
+
+impl NewJobDefinition<'_> {
+    pub fn new_execute(items: &[NewExecuteJobItem]) -> NewJobDefinition<'_> {
+        NewJobDefinition::ExecuteJobDefinition {
+            backend_config: NewBackendConfig::selene(),
+            items,
+        }
+    }
+
+    fn job_type(&self) -> &'static str {
+        match self {
+            Self::ExecuteJobDefinition { .. } => "execute",
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct NewJobAttributes<'a> {
+    name: &'a str,
+    description: Option<&'a str>,
+    properties: JobProperties,
+    job_type: &'static str,
+    definition: NewJobDefinition<'a>,
+}
+
+#[derive(Debug, Serialize)]
+struct NewJobData<'a> {
+    attributes: NewJobAttributes<'a>,
+    relationships: NewJobRelationships,
+    r#type: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+pub struct NewJob<'a> {
+    data: NewJobData<'a>,
+}
+
+impl NewJob<'_> {
+    pub fn new<'a>(
+        name: &'a str,
+        description: Option<&'a str>,
+        project_id: Uuid,
+        definition: NewJobDefinition<'a>,
+    ) -> NewJob<'a> {
+        NewJob {
+            data: NewJobData {
+                attributes: NewJobAttributes {
+                    name,
+                    description,
+                    properties: JobProperties {},
+                    job_type: definition.job_type(),
+                    definition,
+                },
+                relationships: NewJobRelationships::new(project_id),
+                r#type: "job",
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum StatusEnum {
+    Completed,
+    Queued,
+    Submitted,
+    Running,
+    Cancelled,
+    Error,
+    Cancelling,
+    Retrying,
+    Terminated,
+    Depleted,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Status {
+    status: StatusEnum,
+    #[allow(unused)]
+    message: String,
+}
+
+impl Status {
+    pub fn status(&self) -> StatusEnum {
+        self.status
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ExecuteJobItem {
+    result_id: Uuid,
+}
+
+impl ExecuteJobItem {
+    pub fn result_id(&self) -> Uuid {
+        self.result_id
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "job_definition_type")]
+#[serde(rename_all = "snake_case")]
+pub enum JobDefinition {
+    ExecuteJobDefinition { items: Vec<ExecuteJobItem> },
+}
+
+#[derive(Debug, Deserialize)]
+pub struct JobAttributes {
+    status: Status,
+    definition: JobDefinition,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct JobData {
+    attributes: JobAttributes,
+}
+
+impl JobData {
+    pub fn status_enum(&self) -> StatusEnum {
+        self.attributes.status.status
+    }
+
+    pub fn definition(self) -> JobDefinition {
+        self.attributes.definition
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Job {
+    data: JobData,
+}
+
+impl Job {
+    pub fn data(self) -> JobData {
+        self.data
+    }
+}

--- a/tierkreis/src/executor/nexus/client/models/projects.rs
+++ b/tierkreis/src/executor/nexus/client/models/projects.rs
@@ -1,0 +1,42 @@
+use serde::Serialize;
+
+#[derive(Serialize)]
+struct ProjectRelationships {}
+
+#[derive(Serialize)]
+struct ProjectProperties {}
+
+#[derive(Serialize)]
+struct NewProjectAttributes<'a> {
+    name: &'a str,
+    description: Option<&'a str>,
+    properties: ProjectProperties,
+}
+
+#[derive(Serialize)]
+struct NewProjectData<'a> {
+    attributes: NewProjectAttributes<'a>,
+    relationships: ProjectRelationships,
+    r#type: &'static str,
+}
+
+#[derive(Serialize)]
+pub struct NewProject<'a> {
+    data: NewProjectData<'a>,
+}
+
+impl NewProject<'_> {
+    pub fn new<'a>(name: &'a str, description: Option<&'a str>) -> NewProject<'a> {
+        NewProject {
+            data: NewProjectData {
+                attributes: NewProjectAttributes {
+                    name,
+                    description,
+                    properties: ProjectProperties {},
+                },
+                relationships: ProjectRelationships {},
+                r#type: "project",
+            },
+        }
+    }
+}

--- a/tierkreis/src/executor/nexus/client/models/results.rs
+++ b/tierkreis/src/executor/nexus/client/models/results.rs
@@ -1,0 +1,42 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum TaggedResultValue {
+    Int(i64),
+    Bool(bool),
+    Float(f64),
+    IntArr(Vec<i64>),
+    BoolArr(Vec<bool>),
+    FloatArr(Vec<f64>),
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TaggedResult(pub String, pub TaggedResultValue);
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct QSysResultAttributes {
+    results: Vec<Vec<TaggedResult>>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct QSysResultData {
+    attributes: QSysResultAttributes,
+}
+
+impl QSysResultData {
+    pub fn results_ref(&self) -> &Vec<Vec<TaggedResult>> {
+        &self.attributes.results
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct QSysResult {
+    data: QSysResultData,
+}
+
+impl QSysResult {
+    pub fn data(self) -> QSysResultData {
+        self.data
+    }
+}


### PR DESCRIPTION
Pre-requisite work for a Nexus Executor, adds the Nexus endpoints required to upload a hugr, submit a job and get the results.

Possibly controversial as it adds a dependency on hugr, but this could be revised. I figure as we will want to add a hugr dependency later this should be reasonably uncontroversial, but it does mean we would need to make sure the hugr version in the runtime and the hugr we submit using the client match.