### PR TITLE
feat: Generate pipe characters for Union types

### DIFF
--- a/docs/source/examples/example_workers/scipy_worker/api/api.py
+++ b/docs/source/examples/example_workers/scipy_worker/api/api.py
@@ -1,7 +1,7 @@
 """Code generated from scipy_worker namespace. Please do not edit."""
 
 # ruff: noqa: F821
-from typing import NamedTuple, Protocol, Union
+from typing import NamedTuple, Protocol
 from tierkreis.controller.data.models import TKR, OpaqueType
 from tierkreis.controller.data.types import Struct
 
@@ -64,7 +64,7 @@ class transpose(NamedTuple):
 
 class reshape(NamedTuple):
     a: TKR[OpaqueType["numpy.ndarray"]]
-    shape: TKR[Union[int, list[int]]]
+    shape: TKR[int | list[int]]
 
     @staticmethod
     def out() -> type[TKR[OpaqueType["numpy.ndarray"]]]:

--- a/tierkreis/tests/controller/test_codegen.py
+++ b/tierkreis/tests/controller/test_codegen.py
@@ -14,11 +14,11 @@ formats: list[tuple[type[PType], str]] = [
     (bytes, "bytes"),
     (NoneType, "NoneType"),
     (list[str], "list[str]"),
-    (list[str | list[str | int]], "list[Union[str, list[Union[str, int]]]]"),
+    (list[str | list[str | int]], "list[str | list[str | int]]"),
     (tuple[str], "tuple[str]"),
     (
         tuple[str | list[str | int], NoneType],
-        "tuple[Union[str, list[Union[str, int]]], NoneType]",
+        "tuple[str | list[str | int], NoneType]",
     ),
 ]
 

--- a/tierkreis/tests/workers/sleep_worker/uv.lock
+++ b/tierkreis/tests/workers/sleep_worker/uv.lock
@@ -184,7 +184,7 @@ requires-dist = [{ name = "tierkreis", editable = "../../../" }]
 
 [[package]]
 name = "tierkreis"
-version = "2.0.12"
+version = "2.1.1"
 source = { editable = "../../../" }
 dependencies = [
     { name = "hugr" },

--- a/tierkreis/tierkreis/aer_worker.py
+++ b/tierkreis/tierkreis/aer_worker.py
@@ -1,7 +1,7 @@
 """Code generated from aer_worker namespace. Please do not edit."""
 
 # ruff: noqa: F821
-from typing import NamedTuple, Union
+from typing import NamedTuple
 from types import NoneType
 from tierkreis.controller.data.models import TKR, OpaqueType
 
@@ -27,7 +27,7 @@ class run_circuit(NamedTuple):
     n_shots: TKR[int]
     simulation_method: TKR[str] | None = None
     n_qubits: TKR[int] | None = None
-    seed: TKR[Union[int, NoneType]] | None = None
+    seed: TKR[int | NoneType] | None = None
 
     @staticmethod
     def out() -> type[TKR[OpaqueType["pytket.backends.backendresult.BackendResult"]]]:
@@ -43,7 +43,7 @@ class run_circuits(NamedTuple):
     n_shots: TKR[list[int]]
     simulation_method: TKR[str] | None = None
     n_qubits: TKR[int] | None = None
-    seed: TKR[Union[int, NoneType]] | None = None
+    seed: TKR[int | NoneType] | None = None
 
     @staticmethod
     def out() -> type[

--- a/tierkreis/tierkreis/builtins/stubs.py
+++ b/tierkreis/tierkreis/builtins/stubs.py
@@ -1,7 +1,7 @@
 """Code generated from builtins namespace. Please do not edit."""
 
 # ruff: noqa: F821
-from typing import NamedTuple, Sequence, Union
+from typing import NamedTuple, Sequence
 from tierkreis.controller.data.models import TKR
 from tierkreis.controller.data.types import PType
 
@@ -39,8 +39,8 @@ class add(NamedTuple):
     b: TKR[float]
 
     @staticmethod
-    def out() -> type[TKR[Union[int, float]]]:
-        return TKR[Union[int, float]]
+    def out() -> type[TKR[int | float]]:
+        return TKR[int | float]
 
     @property
     def namespace(self) -> str:
@@ -65,8 +65,8 @@ class subtract(NamedTuple):
     b: TKR[float]
 
     @staticmethod
-    def out() -> type[TKR[Union[int, float]]]:
-        return TKR[Union[int, float]]
+    def out() -> type[TKR[int | float]]:
+        return TKR[int | float]
 
     @property
     def namespace(self) -> str:
@@ -91,8 +91,8 @@ class times(NamedTuple):
     b: TKR[float]
 
     @staticmethod
-    def out() -> type[TKR[Union[int, float]]]:
-        return TKR[Union[int, float]]
+    def out() -> type[TKR[int | float]]:
+        return TKR[int | float]
 
     @property
     def namespace(self) -> str:
@@ -220,8 +220,8 @@ class tkr_pow(NamedTuple):
     b: TKR[float]
 
     @staticmethod
-    def out() -> type[TKR[Union[int, float]]]:
-        return TKR[Union[int, float]]
+    def out() -> type[TKR[int | float]]:
+        return TKR[int | float]
 
     @property
     def namespace(self) -> str:
@@ -232,8 +232,8 @@ class tkr_abs(NamedTuple):
     a: TKR[float]
 
     @staticmethod
-    def out() -> type[TKR[Union[int, float]]]:
-        return TKR[Union[int, float]]
+    def out() -> type[TKR[int | float]]:
+        return TKR[int | float]
 
     @property
     def namespace(self) -> str:
@@ -570,8 +570,8 @@ class concat_lists[U: PType, V: PType](NamedTuple):
     second: TKR[list[V]]
 
     @staticmethod
-    def out() -> type[TKR[list[Union[U, V]]]]:
-        return TKR[list[Union[U, V]]]
+    def out() -> type[TKR[list[U | V]]]:
+        return TKR[list[U | V]]
 
     @property
     def namespace(self) -> str:
@@ -579,7 +579,7 @@ class concat_lists[U: PType, V: PType](NamedTuple):
 
 
 class tkr_str(NamedTuple):
-    value: TKR[Union[float, bool]]
+    value: TKR[float | bool]
 
     @staticmethod
     def out() -> type[TKR[str]]:
@@ -591,7 +591,7 @@ class tkr_str(NamedTuple):
 
 
 class tkr_int(NamedTuple):
-    value: TKR[Union[float, bool, str]]
+    value: TKR[float | bool | str]
 
     @staticmethod
     def out() -> type[TKR[int]]:
@@ -603,11 +603,11 @@ class tkr_int(NamedTuple):
 
 
 class sum_list(NamedTuple):
-    values: TKR[list[Union[int, float]]]
+    values: TKR[list[int | float]]
 
     @staticmethod
-    def out() -> type[TKR[Union[int, float]]]:
-        return TKR[Union[int, float]]
+    def out() -> type[TKR[int | float]]:
+        return TKR[int | float]
 
     @property
     def namespace(self) -> str:
@@ -615,11 +615,11 @@ class sum_list(NamedTuple):
 
 
 class prod_list(NamedTuple):
-    values: TKR[list[Union[int, float]]]
+    values: TKR[list[int | float]]
 
     @staticmethod
-    def out() -> type[TKR[Union[int, float]]]:
-        return TKR[Union[int, float]]
+    def out() -> type[TKR[int | float]]:
+        return TKR[int | float]
 
     @property
     def namespace(self) -> str:
@@ -627,11 +627,11 @@ class prod_list(NamedTuple):
 
 
 class max_item(NamedTuple):
-    values: TKR[list[Union[int, float]]]
+    values: TKR[list[int | float]]
 
     @staticmethod
-    def out() -> type[TKR[Union[int, float]]]:
-        return TKR[Union[int, float]]
+    def out() -> type[TKR[int | float]]:
+        return TKR[int | float]
 
     @property
     def namespace(self) -> str:
@@ -639,11 +639,11 @@ class max_item(NamedTuple):
 
 
 class min_item(NamedTuple):
-    values: TKR[list[Union[int, float]]]
+    values: TKR[list[int | float]]
 
     @staticmethod
-    def out() -> type[TKR[Union[int, float]]]:
-        return TKR[Union[int, float]]
+    def out() -> type[TKR[int | float]]:
+        return TKR[int | float]
 
     @property
     def namespace(self) -> str:
@@ -651,11 +651,11 @@ class min_item(NamedTuple):
 
 
 class sort_number_list(NamedTuple):
-    values: TKR[list[Union[int, float]]]
+    values: TKR[list[int | float]]
 
     @staticmethod
-    def out() -> type[TKR[list[Union[int, float]]]]:
-        return TKR[list[Union[int, float]]]
+    def out() -> type[TKR[list[int | float]]]:
+        return TKR[list[int | float]]
 
     @property
     def namespace(self) -> str:

--- a/tierkreis/tierkreis/codegen.py
+++ b/tierkreis/tierkreis/codegen.py
@@ -36,8 +36,6 @@ def format_ptype(
         (DictConvertible, ListConvertible, NdarraySurrogate, BaseModel, Package),
     ):
         return f'OpaqueType["{ptype.__module__}.{ptype.__qualname__}"]'
-    if _is_union(ptype):
-        return "Union"
     if ptype is NoneType or ptype is None:
         return "NoneType"
     if has_serialization:
@@ -67,6 +65,14 @@ def format_generic_type(
     bound_str = ": PType" if include_bound else ""
     if isinstance(generictype, str):
         out = generictype + bound_str
+        return f"TKR[{out}]" if is_tkr else out
+
+    if _is_union(generictype.origin):
+        variants = [
+            format_generic_type(x, include_bound=include_bound, is_tkr=False)
+            for x in generictype.args
+        ]
+        out = " | ".join(variants)
         return f"TKR[{out}]" if is_tkr else out
 
     origin_str = format_ptype(

--- a/tierkreis/tierkreis/nexus_worker.py
+++ b/tierkreis/tierkreis/nexus_worker.py
@@ -1,7 +1,7 @@
 """Code generated from nexus_worker namespace. Please do not edit."""
 
 # ruff: noqa: F821
-from typing import NamedTuple, Union
+from typing import NamedTuple
 from types import NoneType
 from tierkreis.controller.data.models import TKR, OpaqueType
 
@@ -13,19 +13,15 @@ class upload_circuit(NamedTuple):
     @staticmethod
     def out() -> type[
         TKR[
-            Union[
-                OpaqueType["qnexus.models.references.CircuitRef"],
-                OpaqueType["qnexus.models.references.HUGRRef"],
-                OpaqueType["qnexus.models.references.QIRRef"],
-            ]
+            OpaqueType["qnexus.models.references.CircuitRef"]
+            | OpaqueType["qnexus.models.references.HUGRRef"]
+            | OpaqueType["qnexus.models.references.QIRRef"]
         ]
     ]:
         return TKR[
-            Union[
-                OpaqueType["qnexus.models.references.CircuitRef"],
-                OpaqueType["qnexus.models.references.HUGRRef"],
-                OpaqueType["qnexus.models.references.QIRRef"],
-            ]
+            OpaqueType["qnexus.models.references.CircuitRef"]
+            | OpaqueType["qnexus.models.references.HUGRRef"]
+            | OpaqueType["qnexus.models.references.QIRRef"]
         ]
 
     @property
@@ -38,28 +34,24 @@ class start_execute_job(NamedTuple):
     job_name: TKR[str]
     circuits: TKR[
         list[
-            Union[
-                OpaqueType["qnexus.models.references.CircuitRef"],
-                OpaqueType["qnexus.models.references.HUGRRef"],
-                OpaqueType["qnexus.models.references.QIRRef"],
-            ]
+            OpaqueType["qnexus.models.references.CircuitRef"]
+            | OpaqueType["qnexus.models.references.HUGRRef"]
+            | OpaqueType["qnexus.models.references.QIRRef"]
         ]
     ]
     n_shots: TKR[list[int]]
     backend_config: TKR[
-        Union[
-            OpaqueType["quantinuum_schemas.models.backend_config.AerConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.AerStateConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.AerUnitaryConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.BraketConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.QuantinuumConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.IBMQConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.IBMQEmulatorConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.QulacsConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.SeleneConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.SelenePlusConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.HeliosConfig"],
-        ]
+        OpaqueType["quantinuum_schemas.models.backend_config.AerConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.AerStateConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.AerUnitaryConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.BraketConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.QuantinuumConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.IBMQConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.IBMQEmulatorConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.QulacsConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.SeleneConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.SelenePlusConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.HeliosConfig"]
     ]
 
     @staticmethod
@@ -75,27 +67,23 @@ class start_single_job(NamedTuple):
     project_name: TKR[str]
     job_name: TKR[str]
     circuit: TKR[
-        Union[
-            OpaqueType["qnexus.models.references.CircuitRef"],
-            OpaqueType["qnexus.models.references.HUGRRef"],
-            OpaqueType["qnexus.models.references.QIRRef"],
-        ]
+        OpaqueType["qnexus.models.references.CircuitRef"]
+        | OpaqueType["qnexus.models.references.HUGRRef"]
+        | OpaqueType["qnexus.models.references.QIRRef"]
     ]
     n_shots: TKR[int]
     backend_config: TKR[
-        Union[
-            OpaqueType["quantinuum_schemas.models.backend_config.AerConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.AerStateConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.AerUnitaryConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.BraketConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.QuantinuumConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.IBMQConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.IBMQEmulatorConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.QulacsConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.SeleneConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.SelenePlusConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.HeliosConfig"],
-        ]
+        OpaqueType["quantinuum_schemas.models.backend_config.AerConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.AerStateConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.AerUnitaryConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.BraketConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.QuantinuumConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.IBMQConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.IBMQEmulatorConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.QulacsConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.SeleneConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.SelenePlusConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.HeliosConfig"]
     ]
 
     @staticmethod
@@ -136,7 +124,7 @@ class get_results(NamedTuple):
 class upload_hugr(NamedTuple):
     hugr_package: TKR[OpaqueType["hugr.package.Package"]]
     project_name: TKR[str]
-    name: TKR[Union[str, NoneType]] | None = None
+    name: TKR[str | NoneType] | None = None
 
     @staticmethod
     def out() -> type[TKR[OpaqueType["qnexus.models.references.HUGRRef"]]]:
@@ -149,10 +137,8 @@ class upload_hugr(NamedTuple):
 
 class cost(NamedTuple):
     hugr_ref: TKR[
-        Union[
-            OpaqueType["qnexus.models.references.HUGRRef"],
-            list[OpaqueType["qnexus.models.references.HUGRRef"]],
-        ]
+        OpaqueType["qnexus.models.references.HUGRRef"]
+        | list[OpaqueType["qnexus.models.references.HUGRRef"]]
     ]
     n_shots: TKR[int]
     project_name: TKR[str]

--- a/tierkreis/tierkreis/pytket_worker.py
+++ b/tierkreis/tierkreis/pytket_worker.py
@@ -1,26 +1,24 @@
 """Code generated from pytket_worker namespace. Please do not edit."""
 
 # ruff: noqa: F821
-from typing import NamedTuple, Union
+from typing import NamedTuple
 from types import NoneType
 from tierkreis.controller.data.models import TKR, OpaqueType
 
 
 class get_backend_info(NamedTuple):
     config: TKR[
-        Union[
-            OpaqueType["quantinuum_schemas.models.backend_config.AerConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.AerStateConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.AerUnitaryConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.BraketConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.QuantinuumConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.IBMQConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.IBMQEmulatorConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.QulacsConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.SeleneConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.SelenePlusConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.HeliosConfig"],
-        ]
+        OpaqueType["quantinuum_schemas.models.backend_config.AerConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.AerStateConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.AerUnitaryConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.BraketConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.QuantinuumConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.IBMQConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.IBMQEmulatorConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.QulacsConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.SeleneConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.SelenePlusConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.HeliosConfig"]
     ]
 
     @staticmethod
@@ -36,8 +34,8 @@ class device_name_from_info(NamedTuple):
     backend_info: TKR[OpaqueType["pytket.backends.backendinfo.BackendInfo"]]
 
     @staticmethod
-    def out() -> type[TKR[Union[str, NoneType]]]:
-        return TKR[Union[str, NoneType]]
+    def out() -> type[TKR[str | NoneType]]:
+        return TKR[str | NoneType]
 
     @property
     def namespace(self) -> str:
@@ -48,19 +46,17 @@ class compile_using_info(NamedTuple):
     circuit: TKR[OpaqueType["pytket._tket.circuit.Circuit"]]
     backend_info: TKR[OpaqueType["pytket.backends.backendinfo.BackendInfo"]]
     config: TKR[
-        Union[
-            OpaqueType["quantinuum_schemas.models.backend_config.AerConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.AerStateConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.AerUnitaryConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.BraketConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.QuantinuumConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.IBMQConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.IBMQEmulatorConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.QulacsConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.SeleneConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.SelenePlusConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.HeliosConfig"],
-        ]
+        OpaqueType["quantinuum_schemas.models.backend_config.AerConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.AerStateConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.AerUnitaryConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.BraketConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.QuantinuumConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.IBMQConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.IBMQEmulatorConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.QulacsConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.SeleneConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.SelenePlusConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.HeliosConfig"]
     ]
     optimisation_level: TKR[int] | None = None
     timeout: TKR[int] | None = None
@@ -125,21 +121,19 @@ class apply_pass(NamedTuple):
 
 
 class compile_generic_with_fixed_pass(NamedTuple):
-    circuit: TKR[Union[OpaqueType["pytket._tket.circuit.Circuit"], str, bytes]]
+    circuit: TKR[OpaqueType["pytket._tket.circuit.Circuit"] | str | bytes]
     input_format: TKR[str] | None = None
     optimisation_level: TKR[int] | None = None
-    gate_set: TKR[Union[list[str], NoneType]] | None = None
-    coupling_map: TKR[Union[list[tuple[int, int]], NoneType]] | None = None
+    gate_set: TKR[list[str] | NoneType] | None = None
+    coupling_map: TKR[list[tuple[int, int]] | NoneType] | None = None
     output_format: TKR[str] | None = None
     optimisation_pass: (
-        TKR[Union[OpaqueType["pytket._tket.passes.BasePass"], NoneType]] | None
+        TKR[OpaqueType["pytket._tket.passes.BasePass"] | NoneType] | None
     ) = None
 
     @staticmethod
-    def out() -> type[
-        TKR[Union[OpaqueType["pytket._tket.circuit.Circuit"], str, bytes]]
-    ]:
-        return TKR[Union[OpaqueType["pytket._tket.circuit.Circuit"], str, bytes]]
+    def out() -> type[TKR[OpaqueType["pytket._tket.circuit.Circuit"] | str | bytes]]:
+        return TKR[OpaqueType["pytket._tket.circuit.Circuit"] | str | bytes]
 
     @property
     def namespace(self) -> str:

--- a/tierkreis/tierkreis/qulacs_worker.py
+++ b/tierkreis/tierkreis/qulacs_worker.py
@@ -1,7 +1,7 @@
 """Code generated from qulacs_worker namespace. Please do not edit."""
 
 # ruff: noqa: F821
-from typing import NamedTuple, Union
+from typing import NamedTuple
 from types import NoneType
 from tierkreis.controller.data.models import TKR, OpaqueType
 
@@ -26,7 +26,7 @@ class run_circuit(NamedTuple):
     n_shots: TKR[int]
     result_type: TKR[str] | None = None
     gpu_sim: TKR[bool] | None = None
-    seed: TKR[Union[int, NoneType]] | None = None
+    seed: TKR[int | NoneType] | None = None
 
     @staticmethod
     def out() -> type[TKR[OpaqueType["pytket.backends.backendresult.BackendResult"]]]:
@@ -42,7 +42,7 @@ class run_circuits(NamedTuple):
     n_shots: TKR[list[int]]
     result_type: TKR[str] | None = None
     gpu_sim: TKR[bool] | None = None
-    seed: TKR[Union[int, NoneType]] | None = None
+    seed: TKR[int | NoneType] | None = None
 
     @staticmethod
     def out() -> type[

--- a/tierkreis_workers/aer_worker/api/api.py
+++ b/tierkreis_workers/aer_worker/api/api.py
@@ -1,7 +1,7 @@
 """Code generated from aer_worker namespace. Please do not edit."""
 
 # ruff: noqa: F821
-from typing import NamedTuple, Union
+from typing import NamedTuple
 from types import NoneType
 from tierkreis.controller.data.models import TKR, OpaqueType
 
@@ -27,7 +27,7 @@ class run_circuit(NamedTuple):
     n_shots: TKR[int]
     simulation_method: TKR[str] | None = None
     n_qubits: TKR[int] | None = None
-    seed: TKR[Union[int, NoneType]] | None = None
+    seed: TKR[int | NoneType] | None = None
 
     @staticmethod
     def out() -> type[TKR[OpaqueType["pytket.backends.backendresult.BackendResult"]]]:
@@ -43,7 +43,7 @@ class run_circuits(NamedTuple):
     n_shots: TKR[list[int]]
     simulation_method: TKR[str] | None = None
     n_qubits: TKR[int] | None = None
-    seed: TKR[Union[int, NoneType]] | None = None
+    seed: TKR[int | NoneType] | None = None
 
     @staticmethod
     def out() -> type[

--- a/tierkreis_workers/guppy_worker/api/api.py
+++ b/tierkreis_workers/guppy_worker/api/api.py
@@ -1,7 +1,7 @@
 """Code generated from guppy_worker namespace. Please do not edit."""
 
 # ruff: noqa: F821
-from typing import NamedTuple, Union
+from typing import NamedTuple
 from types import NoneType
 from tierkreis.controller.data.models import TKR, OpaqueType
 
@@ -10,7 +10,7 @@ class emulate(NamedTuple):
     hugr_package: TKR[OpaqueType["hugr.package.Package"]]
     n_qubits: TKR[int]
     n_shots: TKR[int]
-    seed: TKR[Union[int, NoneType]] | None = None
+    seed: TKR[int | NoneType] | None = None
 
     @staticmethod
     def out() -> type[TKR[OpaqueType["guppylang.emulator.result.EmulatorResult"]]]:
@@ -160,8 +160,8 @@ class to_qir(NamedTuple):
     package: TKR[OpaqueType["hugr.package.Package"]]
 
     @staticmethod
-    def out() -> type[TKR[Union[bytes, str]]]:
-        return TKR[Union[bytes, str]]
+    def out() -> type[TKR[bytes | str]]:
+        return TKR[bytes | str]
 
     @property
     def namespace(self) -> str:

--- a/tierkreis_workers/nexus_worker/api/api.py
+++ b/tierkreis_workers/nexus_worker/api/api.py
@@ -1,7 +1,7 @@
 """Code generated from nexus_worker namespace. Please do not edit."""
 
 # ruff: noqa: F821
-from typing import NamedTuple, Union
+from typing import NamedTuple
 from types import NoneType
 from tierkreis.controller.data.models import TKR, OpaqueType
 
@@ -13,19 +13,15 @@ class upload_circuit(NamedTuple):
     @staticmethod
     def out() -> type[
         TKR[
-            Union[
-                OpaqueType["qnexus.models.references.CircuitRef"],
-                OpaqueType["qnexus.models.references.HUGRRef"],
-                OpaqueType["qnexus.models.references.QIRRef"],
-            ]
+            OpaqueType["qnexus.models.references.CircuitRef"]
+            | OpaqueType["qnexus.models.references.HUGRRef"]
+            | OpaqueType["qnexus.models.references.QIRRef"]
         ]
     ]:
         return TKR[
-            Union[
-                OpaqueType["qnexus.models.references.CircuitRef"],
-                OpaqueType["qnexus.models.references.HUGRRef"],
-                OpaqueType["qnexus.models.references.QIRRef"],
-            ]
+            OpaqueType["qnexus.models.references.CircuitRef"]
+            | OpaqueType["qnexus.models.references.HUGRRef"]
+            | OpaqueType["qnexus.models.references.QIRRef"]
         ]
 
     @property
@@ -38,28 +34,24 @@ class start_execute_job(NamedTuple):
     job_name: TKR[str]
     circuits: TKR[
         list[
-            Union[
-                OpaqueType["qnexus.models.references.CircuitRef"],
-                OpaqueType["qnexus.models.references.HUGRRef"],
-                OpaqueType["qnexus.models.references.QIRRef"],
-            ]
+            OpaqueType["qnexus.models.references.CircuitRef"]
+            | OpaqueType["qnexus.models.references.HUGRRef"]
+            | OpaqueType["qnexus.models.references.QIRRef"]
         ]
     ]
     n_shots: TKR[list[int]]
     backend_config: TKR[
-        Union[
-            OpaqueType["quantinuum_schemas.models.backend_config.AerConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.AerStateConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.AerUnitaryConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.BraketConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.QuantinuumConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.IBMQConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.IBMQEmulatorConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.QulacsConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.SeleneConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.SelenePlusConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.HeliosConfig"],
-        ]
+        OpaqueType["quantinuum_schemas.models.backend_config.AerConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.AerStateConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.AerUnitaryConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.BraketConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.QuantinuumConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.IBMQConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.IBMQEmulatorConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.QulacsConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.SeleneConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.SelenePlusConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.HeliosConfig"]
     ]
 
     @staticmethod
@@ -75,27 +67,23 @@ class start_single_job(NamedTuple):
     project_name: TKR[str]
     job_name: TKR[str]
     circuit: TKR[
-        Union[
-            OpaqueType["qnexus.models.references.CircuitRef"],
-            OpaqueType["qnexus.models.references.HUGRRef"],
-            OpaqueType["qnexus.models.references.QIRRef"],
-        ]
+        OpaqueType["qnexus.models.references.CircuitRef"]
+        | OpaqueType["qnexus.models.references.HUGRRef"]
+        | OpaqueType["qnexus.models.references.QIRRef"]
     ]
     n_shots: TKR[int]
     backend_config: TKR[
-        Union[
-            OpaqueType["quantinuum_schemas.models.backend_config.AerConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.AerStateConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.AerUnitaryConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.BraketConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.QuantinuumConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.IBMQConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.IBMQEmulatorConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.QulacsConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.SeleneConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.SelenePlusConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.HeliosConfig"],
-        ]
+        OpaqueType["quantinuum_schemas.models.backend_config.AerConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.AerStateConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.AerUnitaryConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.BraketConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.QuantinuumConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.IBMQConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.IBMQEmulatorConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.QulacsConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.SeleneConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.SelenePlusConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.HeliosConfig"]
     ]
 
     @staticmethod
@@ -136,7 +124,7 @@ class get_results(NamedTuple):
 class upload_hugr(NamedTuple):
     hugr_package: TKR[OpaqueType["hugr.package.Package"]]
     project_name: TKR[str]
-    name: TKR[Union[str, NoneType]] | None = None
+    name: TKR[str | NoneType] | None = None
 
     @staticmethod
     def out() -> type[TKR[OpaqueType["qnexus.models.references.HUGRRef"]]]:
@@ -149,10 +137,8 @@ class upload_hugr(NamedTuple):
 
 class cost(NamedTuple):
     hugr_ref: TKR[
-        Union[
-            OpaqueType["qnexus.models.references.HUGRRef"],
-            list[OpaqueType["qnexus.models.references.HUGRRef"]],
-        ]
+        OpaqueType["qnexus.models.references.HUGRRef"]
+        | list[OpaqueType["qnexus.models.references.HUGRRef"]]
     ]
     n_shots: TKR[int]
     project_name: TKR[str]

--- a/tierkreis_workers/pytket_worker/api/api.py
+++ b/tierkreis_workers/pytket_worker/api/api.py
@@ -1,26 +1,24 @@
 """Code generated from pytket_worker namespace. Please do not edit."""
 
 # ruff: noqa: F821
-from typing import NamedTuple, Union
+from typing import NamedTuple
 from types import NoneType
 from tierkreis.controller.data.models import TKR, OpaqueType
 
 
 class get_backend_info(NamedTuple):
     config: TKR[
-        Union[
-            OpaqueType["quantinuum_schemas.models.backend_config.AerConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.AerStateConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.AerUnitaryConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.BraketConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.QuantinuumConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.IBMQConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.IBMQEmulatorConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.QulacsConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.SeleneConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.SelenePlusConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.HeliosConfig"],
-        ]
+        OpaqueType["quantinuum_schemas.models.backend_config.AerConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.AerStateConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.AerUnitaryConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.BraketConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.QuantinuumConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.IBMQConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.IBMQEmulatorConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.QulacsConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.SeleneConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.SelenePlusConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.HeliosConfig"]
     ]
 
     @staticmethod
@@ -36,8 +34,8 @@ class device_name_from_info(NamedTuple):
     backend_info: TKR[OpaqueType["pytket.backends.backendinfo.BackendInfo"]]
 
     @staticmethod
-    def out() -> type[TKR[Union[str, NoneType]]]:
-        return TKR[Union[str, NoneType]]
+    def out() -> type[TKR[str | NoneType]]:
+        return TKR[str | NoneType]
 
     @property
     def namespace(self) -> str:
@@ -48,19 +46,17 @@ class compile_using_info(NamedTuple):
     circuit: TKR[OpaqueType["pytket._tket.circuit.Circuit"]]
     backend_info: TKR[OpaqueType["pytket.backends.backendinfo.BackendInfo"]]
     config: TKR[
-        Union[
-            OpaqueType["quantinuum_schemas.models.backend_config.AerConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.AerStateConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.AerUnitaryConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.BraketConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.QuantinuumConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.IBMQConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.IBMQEmulatorConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.QulacsConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.SeleneConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.SelenePlusConfig"],
-            OpaqueType["quantinuum_schemas.models.backend_config.HeliosConfig"],
-        ]
+        OpaqueType["quantinuum_schemas.models.backend_config.AerConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.AerStateConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.AerUnitaryConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.BraketConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.QuantinuumConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.IBMQConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.IBMQEmulatorConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.QulacsConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.SeleneConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.SelenePlusConfig"]
+        | OpaqueType["quantinuum_schemas.models.backend_config.HeliosConfig"]
     ]
     optimisation_level: TKR[int] | None = None
     timeout: TKR[int] | None = None
@@ -125,21 +121,19 @@ class apply_pass(NamedTuple):
 
 
 class compile_generic_with_fixed_pass(NamedTuple):
-    circuit: TKR[Union[OpaqueType["pytket._tket.circuit.Circuit"], str, bytes]]
+    circuit: TKR[OpaqueType["pytket._tket.circuit.Circuit"] | str | bytes]
     input_format: TKR[str] | None = None
     optimisation_level: TKR[int] | None = None
-    gate_set: TKR[Union[list[str], NoneType]] | None = None
-    coupling_map: TKR[Union[list[tuple[int, int]], NoneType]] | None = None
+    gate_set: TKR[list[str] | NoneType] | None = None
+    coupling_map: TKR[list[tuple[int, int]] | NoneType] | None = None
     output_format: TKR[str] | None = None
     optimisation_pass: (
-        TKR[Union[OpaqueType["pytket._tket.passes.BasePass"], NoneType]] | None
+        TKR[OpaqueType["pytket._tket.passes.BasePass"] | NoneType] | None
     ) = None
 
     @staticmethod
-    def out() -> type[
-        TKR[Union[OpaqueType["pytket._tket.circuit.Circuit"], str, bytes]]
-    ]:
-        return TKR[Union[OpaqueType["pytket._tket.circuit.Circuit"], str, bytes]]
+    def out() -> type[TKR[OpaqueType["pytket._tket.circuit.Circuit"] | str | bytes]]:
+        return TKR[OpaqueType["pytket._tket.circuit.Circuit"] | str | bytes]
 
     @property
     def namespace(self) -> str:

--- a/tierkreis_workers/qulacs_worker/api/api.py
+++ b/tierkreis_workers/qulacs_worker/api/api.py
@@ -1,7 +1,7 @@
 """Code generated from qulacs_worker namespace. Please do not edit."""
 
 # ruff: noqa: F821
-from typing import NamedTuple, Union
+from typing import NamedTuple
 from types import NoneType
 from tierkreis.controller.data.models import TKR, OpaqueType
 
@@ -26,7 +26,7 @@ class run_circuit(NamedTuple):
     n_shots: TKR[int]
     result_type: TKR[str] | None = None
     gpu_sim: TKR[bool] | None = None
-    seed: TKR[Union[int, NoneType]] | None = None
+    seed: TKR[int | NoneType] | None = None
 
     @staticmethod
     def out() -> type[TKR[OpaqueType["pytket.backends.backendresult.BackendResult"]]]:
@@ -42,7 +42,7 @@ class run_circuits(NamedTuple):
     n_shots: TKR[list[int]]
     result_type: TKR[str] | None = None
     gpu_sim: TKR[bool] | None = None
-    seed: TKR[Union[int, NoneType]] | None = None
+    seed: TKR[int | NoneType] | None = None
 
     @staticmethod
     def out() -> type[


### PR DESCRIPTION
Modernise type stubs to include newer 3.10+ pipe characters for Union type syntax. Will make newer versions of linters such as ruff happier.