### PR TITLE
chore: Use assert_matches in tests

### DIFF
--- a/tierkreis/src/event.rs
+++ b/tierkreis/src/event.rs
@@ -503,6 +503,8 @@ pub async fn send_workflow_run_queued(
 mod tests {
     use super::*;
 
+    use std::assert_matches;
+
     use miette::miette;
 
     // Test that we populate the detail field of error events
@@ -517,8 +519,7 @@ mod tests {
         send_error(&mut send, Uuid::nil(), 0, Location::root(), &err).await?;
 
         let event = recv.recv().await.into_diagnostic()?;
-        dbg!(&event);
-        assert!(matches!(
+        assert_matches!(
             event,
             RuntimeEvent::WorkflowRun {
                 event: WorkflowRunEvent::NodeEvent(NodeEvent {
@@ -536,7 +537,7 @@ First Context
 Which was caused by:
 
 Root cause".to_string())
-        ));
+        );
 
         Ok(())
     }

--- a/tierkreis/src/executor/inmemory.rs
+++ b/tierkreis/src/executor/inmemory.rs
@@ -560,6 +560,8 @@ impl Executor for InMemoryExecutor {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
+
     use futures::StreamExt;
     use rstest::rstest;
     use serde_json::json;
@@ -613,9 +615,8 @@ mod tests {
         executor.execute(task_plans).await?;
 
         let events = stream.take(2).collect::<Vec<_>>().await;
-        dbg!(&events);
         assert_eq!(events.len(), 2);
-        assert!(matches!(
+        assert_matches!(
             events[0],
             RuntimeEvent::WorkflowRun {
                 event: WorkflowRunEvent::NodeEvent(NodeEvent {
@@ -624,8 +625,8 @@ mod tests {
                 }),
                 ..
             }
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             events[1],
             RuntimeEvent::WorkflowRun {
                 event: WorkflowRunEvent::NodeEvent(NodeEvent {
@@ -634,7 +635,7 @@ mod tests {
                 }),
                 ..
             }
-        ));
+        );
         assert_registry_contains_values(
             &registry,
             default_storage_name,
@@ -674,7 +675,7 @@ mod tests {
 
         let events = stream.take(2).collect::<Vec<_>>().await;
         assert_eq!(events.len(), 2);
-        assert!(matches!(
+        assert_matches!(
             events[0],
             RuntimeEvent::WorkflowRun {
                 event: WorkflowRunEvent::NodeEvent(NodeEvent {
@@ -683,8 +684,8 @@ mod tests {
                 }),
                 ..
             }
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             events[1],
             RuntimeEvent::WorkflowRun {
                 event: WorkflowRunEvent::NodeEvent(NodeEvent {
@@ -693,7 +694,7 @@ mod tests {
                 }),
                 ..
             }
-        ));
+        );
         assert_registry_contains_values(
             &registry,
             default_storage_name,
@@ -833,7 +834,7 @@ mod tests {
 
         let events = stream.take(2).collect::<Vec<_>>().await;
         assert_eq!(events.len(), 2);
-        assert!(matches!(
+        assert_matches!(
             events[0],
             RuntimeEvent::WorkflowRun {
                 event: WorkflowRunEvent::NodeEvent(NodeEvent {
@@ -842,8 +843,8 @@ mod tests {
                 }),
                 ..
             }
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             events[1],
             RuntimeEvent::WorkflowRun {
                 event: WorkflowRunEvent::NodeEvent(NodeEvent {
@@ -852,7 +853,7 @@ mod tests {
                 }),
                 ..
             }
-        ));
+        );
         assert_registry_contains_values(
             &registry,
             "memory",
@@ -885,7 +886,7 @@ mod tests {
 
         let events = stream.take(2).collect::<Vec<_>>().await;
         assert_eq!(events.len(), 2);
-        assert!(matches!(
+        assert_matches!(
             events[0],
             RuntimeEvent::WorkflowRun {
                 event: WorkflowRunEvent::NodeEvent(NodeEvent {
@@ -894,8 +895,8 @@ mod tests {
                 }),
                 ..
             }
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             events[1],
             RuntimeEvent::WorkflowRun {
                 event: WorkflowRunEvent::NodeEvent(NodeEvent {
@@ -904,7 +905,7 @@ mod tests {
                 }),
                 ..
             } if error == "Unknown task: `backflip`"
-        ));
+        );
 
         Ok(())
     }
@@ -932,7 +933,7 @@ mod tests {
         executor.execute(task_plans).await?;
 
         let event = stream.next().await.unwrap();
-        assert!(matches!(
+        assert_matches!(
             event,
             RuntimeEvent::WorkflowRun {
                 event: WorkflowRunEvent::NodeEvent(NodeEvent {
@@ -941,12 +942,12 @@ mod tests {
                 }),
                 ..
             }
-        ));
+        );
 
         executor.cancel(Uuid::nil(), 0, vec![loc]).await?;
 
         let event = stream.next().await.unwrap();
-        assert!(matches!(
+        assert_matches!(
             event,
             RuntimeEvent::WorkflowRun {
                 event: WorkflowRunEvent::NodeEvent(NodeEvent {
@@ -955,7 +956,7 @@ mod tests {
                 }),
                 ..
             }
-        ));
+        );
 
         Ok(())
     }
@@ -997,7 +998,7 @@ mod tests {
 
         let events = stream.take(2).collect::<Vec<_>>().await;
         assert_eq!(events.len(), 2);
-        assert!(matches!(
+        assert_matches!(
             events[0],
             RuntimeEvent::WorkflowRun {
                 event: WorkflowRunEvent::NodeEvent(NodeEvent {
@@ -1006,8 +1007,8 @@ mod tests {
                 }),
                 ..
             }
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             events[1],
             RuntimeEvent::WorkflowRun {
                 event: WorkflowRunEvent::NodeEvent(NodeEvent {
@@ -1016,7 +1017,7 @@ mod tests {
                 }),
                 ..
             }
-        ));
+        );
         assert_registry_contains_values(
             &registry,
             "memory",

--- a/tierkreis/src/executor/nexus.rs
+++ b/tierkreis/src/executor/nexus.rs
@@ -655,6 +655,8 @@ impl Executor for NexusExecutor {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
+
     use axum::{
         Json, Router,
         extract::{
@@ -877,7 +879,7 @@ mod tests {
 
         let events = stream.take(4).collect::<Vec<_>>().await;
         assert_eq!(events.len(), 4);
-        assert!(matches!(
+        assert_matches!(
             events[0],
             RuntimeEvent::WorkflowRun {
                 event: WorkflowRunEvent::NodeEvent(NodeEvent {
@@ -886,8 +888,8 @@ mod tests {
                 }),
                 ..
             }
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             events[1],
             RuntimeEvent::WorkflowRun {
                 event: WorkflowRunEvent::NodeEvent(NodeEvent {
@@ -896,8 +898,8 @@ mod tests {
                 }),
                 ..
             }
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             events[2],
             RuntimeEvent::WorkflowRun {
                 event: WorkflowRunEvent::NodeEvent(NodeEvent {
@@ -906,8 +908,8 @@ mod tests {
                 }),
                 ..
             }
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             events[3],
             RuntimeEvent::WorkflowRun {
                 event: WorkflowRunEvent::NodeEvent(NodeEvent {
@@ -916,7 +918,7 @@ mod tests {
                 }),
                 ..
             }
-        ));
+        );
 
         assert_registry_contains_values(
             &registry,
@@ -1017,7 +1019,7 @@ mod tests {
 
         let events = stream.take(2).collect::<Vec<_>>().await;
         assert_eq!(events.len(), 2);
-        assert!(matches!(
+        assert_matches!(
             events[0],
             RuntimeEvent::WorkflowRun {
                 event: WorkflowRunEvent::NodeEvent(NodeEvent {
@@ -1026,8 +1028,8 @@ mod tests {
                 }),
                 ..
             }
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             events[1],
             RuntimeEvent::WorkflowRun {
                 event: WorkflowRunEvent::NodeEvent(NodeEvent {
@@ -1036,7 +1038,7 @@ mod tests {
                 }),
                 ..
             } if error == "Job failed with message: job has errored"
-        ));
+        );
 
         Ok(())
     }
@@ -1146,7 +1148,7 @@ mod tests {
         executor.cancel(Uuid::nil(), 0, vec![loc]).await?;
 
         let event = stream.next().await.unwrap();
-        assert!(matches!(
+        assert_matches!(
             event,
             RuntimeEvent::WorkflowRun {
                 event: WorkflowRunEvent::NodeEvent(NodeEvent {
@@ -1155,11 +1157,10 @@ mod tests {
                 }),
                 ..
             }
-        ));
+        );
 
         let event = stream.next().await.unwrap();
-        dbg!(&event);
-        assert!(matches!(
+        assert_matches!(
             event,
             RuntimeEvent::WorkflowRun {
                 event: WorkflowRunEvent::NodeEvent(NodeEvent {
@@ -1168,7 +1169,7 @@ mod tests {
                 }),
                 ..
             }
-        ));
+        );
 
         Ok(())
     }

--- a/tierkreis/src/executor/subprocess.rs
+++ b/tierkreis/src/executor/subprocess.rs
@@ -664,6 +664,7 @@ impl Executor for SubprocessExecutor {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
     use std::collections::HashSet;
 
     use futures::StreamExt;
@@ -730,7 +731,7 @@ mod tests {
 
         let events = stream.take(3).collect::<Vec<_>>().await;
         assert_eq!(events.len(), 3);
-        assert!(matches!(
+        assert_matches!(
             events[0],
             RuntimeEvent::WorkflowRun {
                 event: WorkflowRunEvent::NodeEvent(NodeEvent {
@@ -739,8 +740,8 @@ mod tests {
                 }),
                 ..
             }
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             events[1],
             RuntimeEvent::WorkflowRun {
                 event: WorkflowRunEvent::NodeEvent(NodeEvent {
@@ -749,8 +750,8 @@ mod tests {
                 }),
                 ..
             }
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             events[2],
             RuntimeEvent::WorkflowRun {
                 event: WorkflowRunEvent::NodeEvent(NodeEvent {
@@ -759,7 +760,7 @@ mod tests {
                 }),
                 ..
             }
-        ));
+        );
         assert_registry_contains_values(
             &registry,
             output_storage_name,
@@ -805,7 +806,7 @@ mod tests {
 
         let events = stream.take(3).collect::<Vec<_>>().await;
         assert_eq!(events.len(), 3);
-        assert!(matches!(
+        assert_matches!(
             events[0],
             RuntimeEvent::WorkflowRun {
                 event: WorkflowRunEvent::NodeEvent(NodeEvent {
@@ -814,8 +815,8 @@ mod tests {
                 }),
                 ..
             }
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             events[1],
             RuntimeEvent::WorkflowRun {
                 event: WorkflowRunEvent::NodeEvent(NodeEvent {
@@ -824,8 +825,8 @@ mod tests {
                 }),
                 ..
             }
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             events[2],
             RuntimeEvent::WorkflowRun {
                 event: WorkflowRunEvent::NodeEvent(NodeEvent {
@@ -834,7 +835,7 @@ mod tests {
                 }),
                 ..
             }
-        ));
+        );
         assert_registry_contains_values(
             &registry,
             output_storage_name,
@@ -894,7 +895,6 @@ mod tests {
         executor.execute(task_plans).await?;
 
         let events = stream.take(6).collect::<Vec<_>>().await;
-        dbg!(&events);
         assert_eq!(events.len(), 6);
         assert!(events.contains(&RuntimeEvent::WorkflowRun {
             workflow_run_id: Uuid::nil(),
@@ -989,7 +989,7 @@ mod tests {
 
         let events = stream.take(3).collect::<Vec<_>>().await;
         assert_eq!(events.len(), 3);
-        assert!(matches!(
+        assert_matches!(
             events[0],
             RuntimeEvent::WorkflowRun {
                 event: WorkflowRunEvent::NodeEvent(NodeEvent {
@@ -998,8 +998,8 @@ mod tests {
                 }),
                 ..
             }
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             events[1],
             RuntimeEvent::WorkflowRun {
                 event: WorkflowRunEvent::NodeEvent(NodeEvent {
@@ -1008,8 +1008,8 @@ mod tests {
                 }),
                 ..
             }
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             events[2],
             RuntimeEvent::WorkflowRun {
                 event: WorkflowRunEvent::NodeEvent(NodeEvent {
@@ -1018,7 +1018,7 @@ mod tests {
                 }),
                 ..
             }
-        ));
+        );
         assert_registry_contains_values(
             &registry,
             "file",
@@ -1051,7 +1051,7 @@ mod tests {
 
         let events = stream.take(3).collect::<Vec<_>>().await;
         assert_eq!(events.len(), 3);
-        assert!(matches!(
+        assert_matches!(
             events[0],
             RuntimeEvent::WorkflowRun {
                 event: WorkflowRunEvent::NodeEvent(NodeEvent {
@@ -1060,8 +1060,8 @@ mod tests {
                 }),
                 ..
             }
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             events[1],
             RuntimeEvent::WorkflowRun {
                 event: WorkflowRunEvent::NodeEvent(NodeEvent {
@@ -1070,8 +1070,8 @@ mod tests {
                 }),
                 ..
             }
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             events[2],
             RuntimeEvent::WorkflowRun {
                 event: WorkflowRunEvent::NodeEvent(NodeEvent {
@@ -1080,7 +1080,7 @@ mod tests {
                 }),
                 ..
             } if error == "Subprocess failed with error code: exit status: 1"
-        ));
+        );
 
         Ok(())
     }
@@ -1114,7 +1114,7 @@ mod tests {
         executor.execute(task_plans).await?;
 
         let event = stream.next().await.unwrap();
-        assert!(matches!(
+        assert_matches!(
             event,
             RuntimeEvent::WorkflowRun {
                 event: WorkflowRunEvent::NodeEvent(NodeEvent {
@@ -1123,9 +1123,9 @@ mod tests {
                 }),
                 ..
             }
-        ));
+        );
         let event = stream.next().await.unwrap();
-        assert!(matches!(
+        assert_matches!(
             event,
             RuntimeEvent::WorkflowRun {
                 event: WorkflowRunEvent::NodeEvent(NodeEvent {
@@ -1134,12 +1134,12 @@ mod tests {
                 }),
                 ..
             }
-        ));
+        );
 
         executor.cancel(Uuid::nil(), 0, vec![loc]).await?;
 
         let event = stream.next().await.unwrap();
-        assert!(matches!(
+        assert_matches!(
             event,
             RuntimeEvent::WorkflowRun {
                 event: WorkflowRunEvent::NodeEvent(NodeEvent {
@@ -1148,7 +1148,7 @@ mod tests {
                 }),
                 ..
             }
-        ));
+        );
 
         Ok(())
     }
@@ -1196,7 +1196,7 @@ mod tests {
 
         let events = stream.take(3).collect::<Vec<_>>().await;
         assert_eq!(events.len(), 3);
-        assert!(matches!(
+        assert_matches!(
             events[0],
             RuntimeEvent::WorkflowRun {
                 event: WorkflowRunEvent::NodeEvent(NodeEvent {
@@ -1205,8 +1205,8 @@ mod tests {
                 }),
                 ..
             }
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             events[1],
             RuntimeEvent::WorkflowRun {
                 event: WorkflowRunEvent::NodeEvent(NodeEvent {
@@ -1215,8 +1215,8 @@ mod tests {
                 }),
                 ..
             }
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             events[2],
             RuntimeEvent::WorkflowRun {
                 event: WorkflowRunEvent::NodeEvent(NodeEvent {
@@ -1225,7 +1225,7 @@ mod tests {
                 }),
                 ..
             }
-        ));
+        );
         assert_registry_contains_values(
             &registry,
             "file",

--- a/tierkreis/src/graph.rs
+++ b/tierkreis/src/graph.rs
@@ -941,9 +941,7 @@ mod tests {
     fn convert_graph(#[case] serialized_graph: &str) -> miette::Result<()> {
         let graph: LegacyWorkflowGraph =
             serde_json::from_str(serialized_graph).into_diagnostic()?;
-        dbg!(&graph);
         let converted = graph.to_workflow_graph()?;
-        dbg!(&converted);
 
         let original: LegacyWorkflowGraph =
             serde_json::from_str(serialized_graph).into_diagnostic()?;

--- a/tierkreis/src/orchestrator.rs
+++ b/tierkreis/src/orchestrator.rs
@@ -1293,6 +1293,7 @@ fn collect_inputs(
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
     use std::sync::Arc;
 
     use futures::StreamExt;
@@ -1560,8 +1561,8 @@ mod tests {
             next_actions(&orchestrator, &workflow_graph, &workflow_run_state, &inputs).await?;
 
         assert_eq!(actions.len(), 2);
-        assert!(matches!(actions[0].kind, ActionKind::SetComplete { .. }));
-        assert!(matches!(actions[1].kind, ActionKind::SetComplete { .. }));
+        assert_matches!(actions[0].kind, ActionKind::SetComplete { .. });
+        assert_matches!(actions[1].kind, ActionKind::SetComplete { .. });
 
         Ok(())
     }
@@ -1597,7 +1598,7 @@ mod tests {
 
         assert_eq!(actions.len(), 1);
         assert_eq!(actions[0].loc, Location::new("N1")?);
-        assert!(matches!(actions[0].kind, ActionKind::SetComplete { .. }));
+        assert_matches!(actions[0].kind, ActionKind::SetComplete { .. });
 
         orchestrator
             .perform_actions(Uuid::nil(), 0, stream::iter(actions.into_iter().map(Ok)))
@@ -1625,12 +1626,12 @@ mod tests {
             actions[0].loc,
             Location::from_node_index_iter([workflow_graph.output_idx()])
         );
-        assert!(matches!(actions[0].kind, ActionKind::SetComplete { .. }));
+        assert_matches!(actions[0].kind, ActionKind::SetComplete { .. });
         assert_eq!(
             actions[1].loc,
             Location::from_node_index_iter([workflow_graph.output_idx()])
         );
-        assert!(matches!(actions[1].kind, ActionKind::WorkflowFinished {}));
+        assert_matches!(actions[1].kind, ActionKind::WorkflowFinished {});
 
         orchestrator
             .perform_actions(
@@ -1688,9 +1689,9 @@ mod tests {
 
         assert_eq!(actions.len(), 2);
         assert_eq!(actions[0].loc, Location::new("N2")?);
-        assert!(matches!(actions[0].kind, ActionKind::SetComplete { .. }));
+        assert_matches!(actions[0].kind, ActionKind::SetComplete { .. });
         assert_eq!(actions[1].loc, Location::new("N1")?);
-        assert!(matches!(actions[1].kind, ActionKind::SetComplete { .. }));
+        assert_matches!(actions[1].kind, ActionKind::SetComplete { .. });
 
         orchestrator
             .perform_actions(Uuid::nil(), 0, stream::iter(actions.into_iter().map(Ok)))
@@ -1724,7 +1725,7 @@ mod tests {
 
         assert_eq!(actions.len(), 1);
         assert_eq!(actions[0].loc, Location::new("N3.N1")?);
-        assert!(matches!(actions[0].kind, ActionKind::SetComplete { .. }));
+        assert_matches!(actions[0].kind, ActionKind::SetComplete { .. });
 
         orchestrator
             .perform_actions(
@@ -1871,25 +1872,25 @@ mod tests {
 
         let a_input_state = workflow_run_state.read(&Location::new("N1")?).await?;
 
-        assert!(matches!(
+        assert_matches!(
             a_input_state,
             NodeState {
                 complete_time: Some(..),
                 outputs: Some(..),
                 ..
             }
-        ));
+        );
 
         let subworkflow_input_state = workflow_run_state.read(&Location::new("N2")?).await?;
 
-        assert!(matches!(
+        assert_matches!(
             subworkflow_input_state,
             NodeState {
                 complete_time: Some(..),
                 outputs: Some(..),
                 ..
             }
-        ));
+        );
 
         let output_state = workflow_run_state.read(&Location::new("N0")?).await?;
 
@@ -1978,25 +1979,25 @@ mod tests {
 
         let a_input_state = workflow_run_state.read(&Location::new("N1")?).await?;
 
-        assert!(matches!(
+        assert_matches!(
             a_input_state,
             NodeState {
                 complete_time: Some(..),
                 outputs: Some(..),
                 ..
             }
-        ));
+        );
 
         let subworkflow_input_state = workflow_run_state.read(&Location::new("N2")?).await?;
 
-        assert!(matches!(
+        assert_matches!(
             subworkflow_input_state,
             NodeState {
                 complete_time: Some(..),
                 outputs: Some(..),
                 ..
             }
-        ));
+        );
 
         let output_state = workflow_run_state
             .read(&Location::from_node_index_iter([


### PR DESCRIPTION
Should make it easier to see when test failures occur without having to edit the tests to add dbg statements.