### PR TITLE
fix: Abort background tasks on Executor drop

### DIFF
--- a/tierkreis/src/executor/inmemory.rs
+++ b/tierkreis/src/executor/inmemory.rs
@@ -470,7 +470,14 @@ pub struct InMemoryExecutor {
     task_sender: TaskSender,
     cancel_sender: CancelSender,
     event_receiver: Mutex<Option<EventReceiver>>,
+    background_abort_handle: AbortHandle,
     output_storage_name: String,
+}
+
+impl Drop for InMemoryExecutor {
+    fn drop(&mut self) {
+        self.background_abort_handle.abort();
+    }
 }
 
 impl InMemoryExecutor {
@@ -497,7 +504,7 @@ impl InMemoryExecutor {
         let (event_sender, event_receiver) = mpsc::channel(64);
         let (cancel_sender, cancel_receiver) = mpsc::channel(64);
         let abort_handles = HashMap::new();
-        tokio::spawn(Box::pin(process_tasks(
+        let background_task = tokio::spawn(Box::pin(process_tasks(
             task_receiver,
             cancel_receiver,
             event_sender,
@@ -509,6 +516,7 @@ impl InMemoryExecutor {
             task_sender,
             cancel_sender,
             event_receiver: Mutex::new(Some(event_receiver)),
+            background_abort_handle: background_task.abort_handle(),
             output_storage_name: output_storage_name.to_string(),
         })
     }

--- a/tierkreis/src/executor/nexus.rs
+++ b/tierkreis/src/executor/nexus.rs
@@ -18,6 +18,7 @@ use futures::{
 };
 use hugr::{envelope::read_envelope, extension::ExtensionRegistry};
 use miette::{Context, IntoDiagnostic, miette};
+use tokio::task::AbortHandle;
 use tracing::{Instrument, instrument, warn};
 use uuid::Uuid;
 
@@ -418,8 +419,15 @@ pub struct NexusExecutor {
     task_sender: TaskSender,
     cancel_sender: CancelSender,
     event_receiver: Mutex<Option<EventReceiver>>,
+    background_abort_handle: AbortHandle,
     output_storage_name: String,
     asset_storage_registry: AssetStorageRegistry,
+}
+
+impl Drop for NexusExecutor {
+    fn drop(&mut self) {
+        self.background_abort_handle.abort();
+    }
 }
 
 impl NexusExecutor {
@@ -448,7 +456,7 @@ impl NexusExecutor {
         let (task_sender, task_receiver) = mpsc::channel(64);
         let (event_sender, event_receiver) = mpsc::channel(64);
         let (cancel_sender, cancel_receiver) = mpsc::channel(64);
-        tokio::spawn(process_tasks(
+        let background_task = tokio::spawn(process_tasks(
             client.clone(),
             task_receiver,
             cancel_sender.clone(),
@@ -463,6 +471,7 @@ impl NexusExecutor {
             task_sender,
             cancel_sender,
             event_receiver: Mutex::new(Some(event_receiver)),
+            background_abort_handle: background_task.abort_handle(),
             output_storage_name: output_storage_name.to_string(),
             asset_storage_registry,
         })

--- a/tierkreis/src/executor/subprocess.rs
+++ b/tierkreis/src/executor/subprocess.rs
@@ -319,6 +319,7 @@ pub struct SubprocessExecutor {
     task_sender: TaskSender,
     cancel_sender: CancelSender,
     event_receiver: Mutex<Option<EventReceiver>>,
+    background_abort_handle: AbortHandle,
 
     // The name of the storage that the subprocess will read
     // and write files from. Must be file based.
@@ -329,6 +330,12 @@ pub struct SubprocessExecutor {
     // no copying will occur.
     output_storage_name: String,
     asset_storage_registry: AssetStorageRegistry,
+}
+
+impl Drop for SubprocessExecutor {
+    fn drop(&mut self) {
+        self.background_abort_handle.abort();
+    }
 }
 
 type OutputSpecs = (HashMap<String, AssetSpec>, HashMap<String, PathBuf>);
@@ -370,7 +377,7 @@ impl SubprocessExecutor {
         let (event_sender, event_receiver) = mpsc::channel(64);
         let (cancel_sender, cancel_receiver) = mpsc::channel(64);
         let abort_handles = HashMap::new();
-        tokio::spawn(process_tasks(
+        let background_task = tokio::spawn(process_tasks(
             task_receiver,
             cancel_receiver,
             event_sender,
@@ -383,6 +390,7 @@ impl SubprocessExecutor {
             task_sender,
             cancel_sender,
             event_receiver: Mutex::new(Some(event_receiver)),
+            background_abort_handle: background_task.abort_handle(),
             subprocess_storage_name: subprocess_storage_name.to_string(),
             output_storage_name: output_storage_name.to_string(),
             asset_storage_registry,


### PR DESCRIPTION
This is more of a fix for testing, but it prevents leaking background tasks once an executor is dropped in the main process. There is some possibility this could be useful if we end up supporting custom per user or per workflow executors later however.