### PR TITLE
chore: Refactor AssetStorage for better AssetKind

### DIFF
--- a/tierkreis/src/asset_storage.rs
+++ b/tierkreis/src/asset_storage.rs
@@ -111,10 +111,10 @@ pub async fn unfold_asset<S: BuildHasher>(
     for asset_value in asset_value_list {
         let asset_key = AssetKey::new();
         let asset_bytes = serde_json::to_vec(&asset_value).into_diagnostic()?;
-        storage.save(&asset_key, asset_bytes).await?;
+        let kind = storage.save(&asset_key, asset_bytes).await?;
 
         asset_spec_list.push(AssetSpec {
-            kind: storage.kind(),
+            kind,
             storage_name: storage_name.clone(),
             asset_key,
         });
@@ -144,11 +144,11 @@ pub async fn save_assets<S: BuildHasher>(
     let mut asset_specs = HashMap::new();
     for (name, raw_asset) in raw_assets {
         let asset_key = AssetKey::new();
-        storage.save(&asset_key, raw_asset).await?;
+        let kind = storage.save(&asset_key, raw_asset).await?;
         asset_specs.insert(
             name,
             AssetSpec {
-                kind: storage.kind(),
+                kind,
                 storage_name: storage_name.to_string(),
                 asset_key,
             },
@@ -176,10 +176,10 @@ pub async fn save_asset(
     })?;
 
     let asset_key = AssetKey::new();
-    storage.save(&asset_key, value).await?;
+    let kind = storage.save(&asset_key, value).await?;
 
     Ok(AssetSpec {
-        kind: storage.kind(),
+        kind,
         storage_name: storage_name.to_string(),
         asset_key,
     })
@@ -243,10 +243,10 @@ pub async fn fold_assets(
     })?;
     let asset_key = AssetKey::new();
     let asset_bytes = serde_json::to_vec(&asset_values).into_diagnostic()?;
-    storage.save(&asset_key, asset_bytes).await?;
+    let kind = storage.save(&asset_key, asset_bytes).await?;
 
     Ok(AssetSpec {
-        kind: storage.kind(),
+        kind,
         asset_key,
         storage_name: storage_name.to_string(),
     })
@@ -286,14 +286,14 @@ pub async fn transfer_assets<S: BuildHasher>(
                 .wrap_err("Failed to load asset")?;
 
             let asset_key = AssetKey::new();
-            storage_to
+            let kind = storage_to
                 .save(&asset_key, asset)
                 .await
                 .wrap_err("Failed to save asset")?;
             transferred.insert(
                 name.clone(),
                 AssetSpec {
-                    kind: storage_to.kind(),
+                    kind,
                     asset_key,
                     storage_name: storage_name_to.to_string(),
                 },
@@ -323,8 +323,9 @@ pub async fn reserve_asset_specs(
     let mut asset_specs = Vec::new();
     for _ in 0..total {
         let asset_key = AssetKey::new();
+        let kind = storage.reserve(&asset_key).await?;
         asset_specs.push(AssetSpec {
-            kind: storage.kind(),
+            kind,
             asset_key,
             storage_name: storage_name.to_string(),
         });
@@ -364,11 +365,11 @@ pub async fn test_storage_registry(
         for (name, value) in inputs {
             let asset_key = AssetKey::new();
             let asset = serde_json::to_vec(&value).unwrap();
-            memory_storage.save(&asset_key, asset).await.unwrap();
+            let kind = memory_storage.save(&asset_key, asset).await.unwrap();
             input_assets.insert(
                 name,
                 AssetSpec {
-                    kind: memory_storage.kind(),
+                    kind,
                     storage_name: memory_storage_name.clone(),
                     asset_key,
                 },
@@ -389,11 +390,11 @@ pub async fn test_storage_registry(
         for (name, value) in inputs {
             let asset_key = AssetKey::new();
             let asset = serde_json::to_vec(&value).unwrap();
-            file_storage.save(&asset_key, asset).await.unwrap();
+            let kind = file_storage.save(&asset_key, asset).await.unwrap();
             input_assets.insert(
                 name,
                 AssetSpec {
-                    kind: file_storage.kind(),
+                    kind,
                     storage_name: file_storage_name.clone(),
                     asset_key,
                 },

--- a/tierkreis/src/asset_storage/file.rs
+++ b/tierkreis/src/asset_storage/file.rs
@@ -3,7 +3,10 @@ This module defines the [`FileAssetStorage`] struct which implements [`AssetStor
 by storing files in a single directory.
 */
 
-use std::path::{Path, PathBuf};
+use std::{
+    ops::Not,
+    path::{Path, PathBuf},
+};
 
 use futures::future::{BoxFuture, FutureExt};
 use miette::{Context, IntoDiagnostic, miette};
@@ -36,37 +39,43 @@ impl FileAssetStorage {
 }
 
 impl AssetStorage for FileAssetStorage {
-    fn kind(&self) -> AssetKind {
-        AssetKind::File {
-            root: self.base_dir.clone(),
-        }
-    }
-
-    fn exists(&self, key: &AssetKey) -> BoxFuture<'_, miette::Result<bool>> {
+    fn reserve(&self, key: &AssetKey) -> BoxFuture<'_, miette::Result<AssetKind>> {
         let location = self.location(key);
         async move {
             tokio::fs::try_exists(&location)
                 .await
                 .into_diagnostic()
                 .wrap_err_with(|| {
-                    miette!("Could not determine whether file exists at location: {location:?}")
+                    miette!(
+                        "Could not determine whether file exists at location: {}",
+                        location.display()
+                    )
+                })?
+                .not()
+                .then(|| AssetKind::File {
+                    root: self.base_dir.clone(),
                 })
+                .ok_or_else(|| miette!("Asset already exists at location: {}", location.display()))
         }
         .boxed()
     }
 
-    fn save(&self, key: &AssetKey, value: Vec<u8>) -> BoxFuture<'_, miette::Result<()>> {
+    fn save(&self, key: &AssetKey, value: Vec<u8>) -> BoxFuture<'_, miette::Result<AssetKind>> {
         let location = self.location(key);
         async move {
             let mut file = File::create(&location)
                 .await
                 .into_diagnostic()
-                .wrap_err_with(|| miette!("Cannot find file at location: {location:?}"))?;
+                .wrap_err_with(|| {
+                    miette!("Cannot find file at location: {}", location.display())
+                })?;
 
             file.write_all(&value).await.into_diagnostic()?;
             file.flush().await.into_diagnostic()?;
 
-            Ok(())
+            Ok(AssetKind::File {
+                root: self.base_dir.clone(),
+            })
         }
         .boxed()
     }
@@ -77,7 +86,9 @@ impl AssetStorage for FileAssetStorage {
             let mut file = File::open(&location)
                 .await
                 .into_diagnostic()
-                .wrap_err_with(|| miette!("Cannot find file at location: {location:?}"))?;
+                .wrap_err_with(|| {
+                    miette!("Cannot find file at location: {}", location.display())
+                })?;
 
             let mut value = Vec::new();
             file.read_to_end(&mut value).await.into_diagnostic()?;

--- a/tierkreis/src/asset_storage/inmemory.rs
+++ b/tierkreis/src/asset_storage/inmemory.rs
@@ -2,6 +2,8 @@
 This module defines the [`InMemoryStorage`] struct which implements [`AssetStorage`]
 by storing files in concurrent map data structure implemented by [`dashmap::DashMap`].
 */
+use std::ops::Not;
+
 use dashmap::DashMap;
 use futures::{
     FutureExt,
@@ -37,17 +39,20 @@ impl Default for InMemoryStorage {
 }
 
 impl AssetStorage for InMemoryStorage {
-    fn kind(&self) -> AssetKind {
-        AssetKind::Memory
+    fn reserve(&self, key: &AssetKey) -> BoxFuture<'_, miette::Result<AssetKind>> {
+        future::ready(
+            self.store
+                .contains_key(key)
+                .not()
+                .then_some(AssetKind::Memory)
+                .ok_or_else(|| miette!("Asset does not exist in memory")),
+        )
+        .boxed()
     }
 
-    fn exists(&self, key: &AssetKey) -> BoxFuture<'_, miette::Result<bool>> {
-        future::ok(self.store.contains_key(key)).boxed()
-    }
-
-    fn save(&self, key: &AssetKey, value: Vec<u8>) -> BoxFuture<'_, miette::Result<()>> {
+    fn save(&self, key: &AssetKey, value: Vec<u8>) -> BoxFuture<'_, miette::Result<AssetKind>> {
         self.store.insert(*key, value);
-        future::ok(()).boxed()
+        future::ok(AssetKind::Memory).boxed()
     }
 
     fn load(&self, key: &AssetKey) -> BoxFuture<'_, miette::Result<Vec<u8>>> {

--- a/tierkreis/src/asset_storage/interface.rs
+++ b/tierkreis/src/asset_storage/interface.rs
@@ -146,20 +146,21 @@ impl Display for AssetKey {
 ///
 /// The interface is essentially a key-value store, keyed by [`AssetKey`]s.
 pub trait AssetStorage: Send + Sync {
-    /// Retrieve the [`AssetKind`] for the [`AssetStorage`].
-    fn kind(&self) -> AssetKind;
-    /// Determine if an Asset exists in the storage for the [`AssetKey`].
+    /// Reserve an [`AssetKey`] for this [`AssetStorage`].
+    ///
+    /// For most implementations this will just involve checking that an Asset does not
+    /// already exist with that key.
     ///
     /// # Errors
     ///
     /// Will return Err if the data backing the [`AssetStorage`] is unreachable or busy.
-    fn exists(&self, key: &AssetKey) -> BoxFuture<'_, miette::Result<bool>>;
+    fn reserve(&self, key: &AssetKey) -> BoxFuture<'_, miette::Result<AssetKind>>;
     /// Save an Asset to the [`AssetStorage`] using an [`AssetKey`].
     ///
     /// # Errors
     ///
     /// Will return Err if the data backing the [`AssetStorage`] is unreachable or busy.
-    fn save(&self, key: &AssetKey, value: Vec<u8>) -> BoxFuture<'_, miette::Result<()>>;
+    fn save(&self, key: &AssetKey, value: Vec<u8>) -> BoxFuture<'_, miette::Result<AssetKind>>;
     /// Load an Asset from the [`AssetStorage`] using an [`AssetKey`].
     ///
     /// # Errors

--- a/tierkreis/src/executor/subprocess.rs
+++ b/tierkreis/src/executor/subprocess.rs
@@ -3,6 +3,7 @@ This module defines the [`SubprocessExecutor`] struct which implements [Executor
 by running subprocesses.
 */
 use std::{
+    any::Any,
     collections::{HashMap, HashSet},
     path::{Path, PathBuf},
     process::{ExitStatus, Stdio},
@@ -31,7 +32,7 @@ use which::which_re;
 
 use crate::{
     asset_storage::{
-        AssetKind, AssetSpec, AssetStorageRegistry, reserve_asset_specs, transfer_assets,
+        AssetSpec, AssetStorageRegistry, FileAssetStorage, reserve_asset_specs, transfer_assets,
     },
     event::{
         EventReceiver, EventSender, NodeEvent, NodeStatus, RuntimeEvent, WorkflowRunEvent,
@@ -359,9 +360,10 @@ impl SubprocessExecutor {
     ) -> miette::Result<Self> {
         let asset_storage_registry_lock = asset_storage_registry.read().await;
         if let Some(subprocess_storage) = asset_storage_registry_lock.get(subprocess_storage_name) {
-            if !matches!(subprocess_storage.kind(), AssetKind::File { .. }) {
+            let subprocess_storage: &dyn Any = subprocess_storage as &dyn Any;
+            if subprocess_storage.is::<FileAssetStorage>() {
                 return Err(miette!(
-                    "subprocess_storage_name must be of AssetKind::File"
+                    "subprocess_storage_name must be an instance of FileAssetStorage"
                 ));
             }
         } else {


### PR DESCRIPTION
Remove the `.kind()` and `.exists()` method for the AssetStorage interface and instead use a `.reserve()` method and allow AssetKind to be dynamic based on the input.

This moves towards being able to include extra information about the Asset itself in AssetKind such as type hints.