### PR TITLE
fix: Set stdout to null in subprocess executor

### DIFF
--- a/tierkreis/src/executor/subprocess.rs
+++ b/tierkreis/src/executor/subprocess.rs
@@ -485,7 +485,7 @@ fn spawn_worker(
 
     command
         .arg(worker_args_path)
-        .stdout(Stdio::piped())
+        .stdout(Stdio::null())
         .stderr(Stdio::piped());
 
     let child = command


### PR DESCRIPTION
We don't currently read stdout, so a noisy subprocess would potentially clog up the executor. Suggested by astra but the code it generated was too sloppy.